### PR TITLE
Fix bug calculating testnet difficulty after DAA hardfork

### DIFF
--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -297,11 +297,6 @@ func (b *BlockChain) calcNextRequiredDifficulty(lastNode *blockNode, newBlockTim
 		if newBlockTime.Unix() > allowMinTime {
 			return b.chainParams.PowLimitBits, nil
 		}
-
-		// The block was mined within the desired timeframe, so
-		// return the difficulty for the last block which did
-		// not have the special minimum difficulty rule applied.
-		return b.findPrevTestNetDifficulty(lastNode), nil
 	}
 
 	// Get the block node at the beginning of the window (n-144)


### PR DESCRIPTION
If the special difficulty rules are not used the difficulty should be calculated
the same as mainnet. However, the code was trying to use the pre-daa way of
calculating difficulty if the difficulty in the testnet case.