### PR TITLE
[Feature] Add kubernetes configs for GCE

### DIFF
--- a/kube/README.md
+++ b/kube/README.md
@@ -1,0 +1,12 @@
+# bchd Kubernetes Configs
+
+The following guide will walk you through creating a bchd full node within GKE (Google Container Engine).
+
+This node will have both transaction and address indexing turned on. If you don't need these features you can edit `kube/bchd-deployment` and update the flags passed to bchd.
+
+Steps:
+1. Add a new blank disk on GCE called `bchd-data` that is 300GB. You can always expand it later.
+2. Change the `rpcuser` and `rpcpass` values in `bchd-secrets.yml`. They are base64 encoded. To base64 a string, just run `echo -n SOMESTRING | base64`.
+3. Run `kubectl create -f /path/to/kube`
+4. Lookup the `bchd-srv` service in the web-ui to get your public ip.
+5. Profit!

--- a/kube/bchd-deployment.yml
+++ b/kube/bchd-deployment.yml
@@ -1,0 +1,45 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: default
+  labels:
+    service: bchd
+    version: 0.12.0-beta
+  name: bchd
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        service: bchd
+    spec:
+      containers:
+      - env:
+        - name: BCHD_RPC_USER
+          valueFrom:
+            secretKeyRef:
+              name: bchd
+              key: rpcuser
+        - name: BCHD_RPC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: bchd
+              key: rpcpass
+        image: zquestz/bchd:0.12.0-beta
+        command: ["./bchd"]
+        args: ["-u", "$(BCHD_RPC_USER)", "-P", "$(BCHD_RPC_PASSWORD)", "--addrindex", "--txindex", "-b", "/data", "-C", "/data/bchd.conf"]
+        name: bchd
+        volumeMounts:
+          - mountPath: /data
+            name: bchd-data
+        resources:
+          requests:
+            memory: "3Gi"
+      restartPolicy: Always
+      volumes:
+        - name: bchd-data
+          gcePersistentDisk:
+            pdName: bchd-data
+            fsType: ext4

--- a/kube/bchd-secrets.yml
+++ b/kube/bchd-secrets.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bchd
+type: Opaque
+data:
+  rpcuser: YWRtaW4=
+  rpcpass: aXRvbGR5b3V0b2NoYW5nZXRoaXM=

--- a/kube/bchd-srv.yml
+++ b/kube/bchd-srv.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bchd
+  namespace: default
+spec:
+  ports:
+    - port: 8333
+      targetPort: 8333
+  selector:
+    service: bchd
+  type: LoadBalancer
+  externalTrafficPolicy: Local


### PR DESCRIPTION
Documentation and configurations for setting up bchd on Kubernetes.

I also have a node live with a very similar config at `bchd.greyh.at:8333`. Seems to be working quite well, although I am still syncing. =)