### PR TITLE
Adjust trickle size and minimum broadcast interval

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -32,7 +32,7 @@ const (
 
 	// DefaultTrickleInterval is the min time between attempts to send an
 	// inv message to a peer.
-	DefaultTrickleInterval = 1 * time.Millisecond
+	DefaultTrickleInterval = 50 * time.Millisecond
 
 	// minAcceptableProtocolVersion is the lowest protocol version that a
 	// connected peer may support.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -43,7 +43,7 @@ const (
 
 	// invTrickleSize is the maximum amount of inventory to send in a single
 	// message when trickling inventory to remote peers.
-	maxInvTrickleSize = 1000
+	maxInvTrickleSize = 5000
 
 	// maxKnownInventory is the maximum number of items to keep in the known
 	// inventory cache.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -32,7 +32,7 @@ const (
 
 	// DefaultTrickleInterval is the min time between attempts to send an
 	// inv message to a peer.
-	DefaultTrickleInterval = 10 * time.Second
+	DefaultTrickleInterval = 1 * time.Millisecond
 
 	// minAcceptableProtocolVersion is the lowest protocol version that a
 	// connected peer may support.


### PR DESCRIPTION
This PR attempts to address issue #41.

This reduces the inventory trickle interval from 10 seconds to 1 millisecond and increases the max size from 1000 to 5000. This makes nodes send more txs at once and reduces the time new txs have to wait before being broadcast. An interval of 0 (that doesn't use a `time.Ticker`) is not supported to prevent a continuous inv flood from starving out other outgoing data tasks in the same `select` as the inv broadcast.