### PR TITLE
Add amount to signrawtransaction btcjson inputs

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -573,10 +573,11 @@ func NewSignMessageCmd(address, message string) *SignMessageCmd {
 // RawTxInput models the data needed for raw transaction input that is used in
 // the SignRawTransactionCmd struct.
 type RawTxInput struct {
-	Txid         string `json:"txid"`
-	Vout         uint32 `json:"vout"`
-	ScriptPubKey string `json:"scriptPubKey"`
-	RedeemScript string `json:"redeemScript"`
+	Txid         string  `json:"txid"`
+	Vout         uint32  `json:"vout"`
+	ScriptPubKey string  `json:"scriptPubKey"`
+	RedeemScript string  `json:"redeemScript"`
+	Amount       float64 `json:"amount"`
 }
 
 // SignRawTransactionCmd defines the signrawtransaction JSON-RPC command.

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -1086,7 +1086,7 @@ func TestWalletSvrCmds(t *testing.T) {
 		{
 			name: "signrawtransaction optional1",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("signrawtransaction", "001122", `[{"txid":"123","vout":1,"scriptPubKey":"00","redeemScript":"01"}]`)
+				return btcjson.NewCmd("signrawtransaction", "001122", `[{"txid":"123","vout":1,"scriptPubKey":"00","redeemScript":"01","amount":0.0001}]`)
 			},
 			staticCmd: func() interface{} {
 				txInputs := []btcjson.RawTxInput{
@@ -1095,12 +1095,13 @@ func TestWalletSvrCmds(t *testing.T) {
 						Vout:         1,
 						ScriptPubKey: "00",
 						RedeemScript: "01",
+						Amount:       0.0001,
 					},
 				}
 
 				return btcjson.NewSignRawTransactionCmd("001122", &txInputs, nil, nil)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"signrawtransaction","params":["001122",[{"txid":"123","vout":1,"scriptPubKey":"00","redeemScript":"01"}]],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"signrawtransaction","params":["001122",[{"txid":"123","vout":1,"scriptPubKey":"00","redeemScript":"01","amount":0.0001}]],"id":1}`,
 			unmarshalled: &btcjson.SignRawTransactionCmd{
 				RawTx: "001122",
 				Inputs: &[]btcjson.RawTxInput{
@@ -1109,6 +1110,7 @@ func TestWalletSvrCmds(t *testing.T) {
 						Vout:         1,
 						ScriptPubKey: "00",
 						RedeemScript: "01",
+						Amount:       0.0001,
 					},
 				},
 				PrivKeys: nil,


### PR DESCRIPTION
The bitcoin cash signing algorithm requires the input values to be hashed
so we need to include the input values in the RPC call. Signrawtransaction
is not directly used by bchd, but it is used in the bchwallet.