### PR TITLE
[Feature] Add MaxPeersPerIP to limit too many connections from a single ip address

### DIFF
--- a/config.go
+++ b/config.go
@@ -39,6 +39,7 @@ const (
 	defaultLogDirname            = "logs"
 	defaultLogFilename           = "bchd.log"
 	defaultMaxPeers              = 125
+	defaultMaxPeersPerIP         = 5
 	defaultBanDuration           = time.Hour * 24
 	defaultBanThreshold          = 100
 	defaultConnectTimeout        = time.Second * 30
@@ -107,6 +108,7 @@ type config struct {
 	DisableListen        bool          `long:"nolisten" description:"Disable listening for incoming connections -- NOTE: Listening is automatically disabled if the --connect or --proxy options are used without also specifying listen interfaces via --listen"`
 	Listeners            []string      `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 8333, testnet: 18333)"`
 	MaxPeers             int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
+	MaxPeersPerIP        int           `long:"maxpeersperip" description:"Max number of inbound and outbound peers per IP"`
 	DisableBanning       bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
 	BanDuration          time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
 	BanThreshold         uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
@@ -411,6 +413,7 @@ func loadConfig() (*config, []string, error) {
 		ConfigFile:           defaultConfigFile,
 		DebugLevel:           defaultLogLevel,
 		MaxPeers:             defaultMaxPeers,
+		MaxPeersPerIP:        defaultMaxPeersPerIP,
 		BanDuration:          defaultBanDuration,
 		BanThreshold:         defaultBanThreshold,
 		RPCMaxClients:        defaultMaxRPCClients,


### PR DESCRIPTION
Sets a limit of 5 incoming and outgoing connections to a particular host. This is configurable via the `maxpeersperip` flag.

Addresses https://github.com/gcash/bchd/issues/40