### PR TITLE
Change getpeerinfo services response to a string

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -234,6 +234,7 @@ type GetPeerInfoResult struct {
 	Addr           string  `json:"addr"`
 	AddrLocal      string  `json:"addrlocal,omitempty"`
 	Services       string  `json:"services"`
+	ServicesStr    string  `json:"servicesStr"`
 	RelayTxes      bool    `json:"relaytxes"`
 	LastSend       int64   `json:"lastsend"`
 	LastRecv       int64   `json:"lastrecv"`

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2451,6 +2451,7 @@ func handleGetPeerInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 			Addr:           statsSnap.Addr,
 			AddrLocal:      p.ToPeer().LocalAddr().String(),
 			Services:       fmt.Sprintf("%08d", uint64(statsSnap.Services)),
+			ServicesStr:    statsSnap.Services.String(),
 			RelayTxes:      !p.IsTxRelayDisabled(),
 			LastSend:       statsSnap.LastSend.Unix(),
 			LastRecv:       statsSnap.LastRecv.Unix(),

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -446,6 +446,7 @@ var helpDescsEnUS = map[string]string{
 	"getpeerinforesult-addr":           "The ip address and port of the peer",
 	"getpeerinforesult-addrlocal":      "Local address",
 	"getpeerinforesult-services":       "Services bitmask which represents the services supported by the peer",
+	"getpeerinforesult-servicesStr":    "Services string which represents the services supported by the peer",
 	"getpeerinforesult-relaytxes":      "Peer has requested transactions be relayed to it",
 	"getpeerinforesult-lastsend":       "Time the last message was received in seconds since 1 Jan 1970 GMT",
 	"getpeerinforesult-lastrecv":       "Time the last message was sent in seconds since 1 Jan 1970 GMT",


### PR DESCRIPTION
The getpeerinfo rpc currently returns the services field as a uint whichis mostly worthless as it's not human readable. This commit changes it to return the string representation of the node's services.

I presume it was done this way so that clients can more easily parse the field, however the main client using it is bchctl and not being human readable is a drawback. Any other clients that need to parse it can still parse the string.