### PR TITLE
[Refactor] Update magneticAnomalyActive bool to ScriptFlags

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1090,7 +1090,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 //
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) connectBestChain(node *blockNode, block *bchutil.Block, flags BehaviorFlags) (bool, error) {
-	fastAdd := flags&BFFastAdd == BFFastAdd
+	fastAdd := flags.HasFlag(BFFastAdd)
 
 	flushIndexState := func() {
 		// Intentionally ignore errors writing updated node status to DB. If
@@ -1142,7 +1142,7 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *bchutil.Block, fla
 			if err != nil {
 				return false, err
 			}
-			if flags&BFMagneticAnomaly == BFMagneticAnomaly {
+			if flags.HasFlag(BFMagneticAnomaly) {
 				view.addBlockOutputs(block)
 				err := view.spendBlockInputs(block, &stxos)
 				if err != nil {

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -38,6 +38,11 @@ const (
 	BFNone BehaviorFlags = 0
 )
 
+// HasFlag returns whether the BehaviorFlags has the passed flag set.
+func (behaviorFlags BehaviorFlags) HasFlag(flag BehaviorFlags) bool {
+	return behaviorFlags&flag == flag
+}
+
 // blockExists determines whether a block with the given hash exists either in
 // the main chain or any side chains.
 //
@@ -148,7 +153,7 @@ func (b *BlockChain) ProcessBlock(block *bchutil.Block, flags BehaviorFlags) (bo
 	b.chainLock.Lock()
 	defer b.chainLock.Unlock()
 
-	fastAdd := flags&BFFastAdd == BFFastAdd
+	fastAdd := flags.HasFlag(BFFastAdd)
 
 	blockHash := block.Hash()
 	log.Tracef("Processing block %v", blockHash)

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -394,7 +394,7 @@ func checkProofOfWork(header *wire.BlockHeader, powLimit *big.Int, flags Behavio
 
 	// The block hash must be less than the claimed target unless the flag
 	// to avoid proof of work checks is set.
-	if flags&BFNoPoWCheck != BFNoPoWCheck {
+	if !flags.HasFlag(BFNoPoWCheck) {
 		// The block hash must be less than the claimed target.
 		hash := header.BlockHash()
 		hashNum := HashToBig(&hash)
@@ -444,7 +444,7 @@ func CountSigOps(tx *bchutil.Tx, scriptFlags txscript.ScriptFlags) int {
 // respecting current active soft-forks which modified sig op cost counting.
 func GetSigOps(tx *bchutil.Tx, isCoinBaseTx bool, utxoView *UtxoViewpoint, scriptFlags txscript.ScriptFlags) (int, error) {
 	numSigOps := CountSigOps(tx, scriptFlags)
-	if scriptFlags&txscript.ScriptBip16 == txscript.ScriptBip16 {
+	if scriptFlags.HasFlag(txscript.ScriptBip16) {
 		numP2SHSigOps, err := CountP2SHSigOps(tx, isCoinBaseTx, utxoView, scriptFlags)
 		if err != nil {
 			return 0, nil
@@ -581,7 +581,7 @@ func checkBlockSanity(block *bchutil.Block, powLimit *big.Int, timeSource Median
 		}
 	}
 
-	magneticAnomaly := flags&BFMagneticAnomaly == BFMagneticAnomaly
+	magneticAnomaly := flags.HasFlag(BFMagneticAnomaly)
 
 	// TODO: This is not a full set of ScriptFlags and only
 	// covers the Nov 2018 fork.
@@ -716,7 +716,7 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 	// block.
 	blockHeight := prevNode.height + 1
 
-	fastAdd := flags&BFFastAdd == BFFastAdd
+	fastAdd := flags.HasFlag(BFFastAdd)
 	if !fastAdd {
 		// Ensure the difficulty specified in the block header matches
 		// the calculated difficulty based on the previous block and
@@ -836,7 +836,7 @@ func (b *BlockChain) checkBlockContext(block *bchutil.Block, prevNode *blockNode
 		return ruleError(ErrBlockTooBig, str)
 	}
 
-	fastAdd := flags&BFFastAdd == BFFastAdd
+	fastAdd := flags.HasFlag(BFFastAdd)
 	if !fastAdd {
 		// Obtain the latest state of the deployed CSV soft-fork in
 		// order to properly guard the new validation behavior based on

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gcash/bchd/chaincfg"
 	"github.com/gcash/bchd/chaincfg/chainhash"
+	"github.com/gcash/bchd/txscript"
 	"github.com/gcash/bchd/wire"
 	"github.com/gcash/bchutil"
 )
@@ -92,13 +93,18 @@ func TestCountSigOps(t *testing.T) {
 	tx := bchutil.NewTx(&msgTx)
 
 	// Before the Nov fork.
-	sigOps := CountSigOps(tx, false)
+	var scriptFlags txscript.ScriptFlags
+	sigOps := CountSigOps(tx, scriptFlags)
 	if sigOps != 0 {
 		t.Fatalf("Incorrect number of SigOps, expected 0 got %v\n", sigOps)
 	}
 
 	// After the Nov fork.
-	sigOps = CountSigOps(tx, true)
+	scriptFlags |= txscript.ScriptVerifySigPushOnly |
+		txscript.ScriptVerifyCleanStack |
+		txscript.ScriptVerifyCheckDataSig
+
+	sigOps = CountSigOps(tx, scriptFlags)
 	if sigOps != 1 {
 		t.Fatalf("Incorrect number of SigOps, expected 1 got %v\n", sigOps)
 	}

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -88,7 +88,7 @@ func calcMinRequiredTxRelayFee(serializedSize int64, minRelayTxFee bchutil.Amoun
 // not perform those checks because the script engine already does this more
 // accurately and concisely via the txscript.ScriptVerifyCleanStack and
 // txscript.ScriptVerifySigPushOnly flags.
-func checkInputsStandard(tx *bchutil.Tx, utxoView *blockchain.UtxoViewpoint, magneticAnomaly bool) error {
+func checkInputsStandard(tx *bchutil.Tx, utxoView *blockchain.UtxoViewpoint, scriptFlags txscript.ScriptFlags) error {
 	// NOTE: The reference implementation also does a coinbase check here,
 	// but coinbases have already been rejected prior to calling this
 	// function so no need to recheck.
@@ -102,7 +102,7 @@ func checkInputsStandard(tx *bchutil.Tx, utxoView *blockchain.UtxoViewpoint, mag
 		switch txscript.GetScriptClass(originPkScript) {
 		case txscript.ScriptHashTy:
 			numSigOps := txscript.GetPreciseSigOpCount(
-				txIn.SignatureScript, originPkScript, true, magneticAnomaly)
+				txIn.SignatureScript, originPkScript, scriptFlags)
 			if numSigOps > maxStandardP2SHSigOps {
 				str := fmt.Sprintf("transaction input #%d has "+
 					"%d signature operations which is more "+

--- a/txscript/engine.go
+++ b/txscript/engine.go
@@ -86,6 +86,11 @@ const (
 	ScriptVerifyCheckDataSig
 )
 
+// HasFlag returns whether the ScriptFlags has the passed flag set.
+func (scriptFlags ScriptFlags) HasFlag(flag ScriptFlags) bool {
+	return scriptFlags&flag == flag
+}
+
 const (
 	// MaxStackSize is the maximum combined height of stack and alt stack
 	// during execution.
@@ -120,7 +125,7 @@ type Engine struct {
 
 // hasFlag returns whether the script engine instance has the passed flag set.
 func (vm *Engine) hasFlag(flag ScriptFlags) bool {
-	return vm.flags&flag == flag
+	return vm.flags.HasFlag(flag)
 }
 
 // isBranchExecuting returns whether or not the current conditional branch is

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -603,7 +603,7 @@ func asSmallInt(op *opcode) int {
 // signature operations in the script provided by pops. If precise mode is
 // requested then we attempt to count the number of operations for a multisig
 // op. Otherwise we use the maximum.
-func getSigOpCount(pops []parsedOpcode, precise bool, magneticAnomalyActive bool) int {
+func getSigOpCount(pops []parsedOpcode, precise bool, scriptFlags ScriptFlags) int {
 	nSigs := 0
 	for i, pop := range pops {
 		switch pop.opcode.value {
@@ -614,7 +614,7 @@ func getSigOpCount(pops []parsedOpcode, precise bool, magneticAnomalyActive bool
 		case OP_CHECKDATASIG:
 			fallthrough
 		case OP_CHECKDATASIGVERIFY:
-			if magneticAnomalyActive {
+			if scriptFlags&ScriptVerifyCheckDataSig == ScriptVerifyCheckDataSig {
 				nSigs++
 			}
 		case OP_CHECKMULTISIG:
@@ -643,11 +643,11 @@ func getSigOpCount(pops []parsedOpcode, precise bool, magneticAnomalyActive bool
 // in a script. a CHECKSIG operations counts for 1, and a CHECK_MULTISIG for 20.
 // If the script fails to parse, then the count up to the point of failure is
 // returned.
-func GetSigOpCount(script []byte, magneticAnomalyActive bool) int {
+func GetSigOpCount(script []byte, scriptFlags ScriptFlags) int {
 	// Don't check error since parseScript returns the parsed-up-to-error
 	// list of pops.
 	pops, _ := parseScript(script)
-	return getSigOpCount(pops, false, magneticAnomalyActive)
+	return getSigOpCount(pops, false, scriptFlags)
 }
 
 // GetPreciseSigOpCount returns the number of signature operations in
@@ -655,14 +655,14 @@ func GetSigOpCount(script []byte, magneticAnomalyActive bool) int {
 // Pay-To-Script-Hash script in order to find the precise number of signature
 // operations in the transaction.  If the script fails to parse, then the count
 // up to the point of failure is returned.
-func GetPreciseSigOpCount(scriptSig, scriptPubKey []byte, bip16 bool, magneticAnomalyActive bool) int {
+func GetPreciseSigOpCount(scriptSig, scriptPubKey []byte, scriptFlags ScriptFlags) int {
 	// Don't check error since parseScript returns the parsed-up-to-error
 	// list of pops.
 	pops, _ := parseScript(scriptPubKey)
 
 	// Treat non P2SH transactions as normal.
-	if !(bip16 && isScriptHash(pops)) {
-		return getSigOpCount(pops, true, magneticAnomalyActive)
+	if !(scriptFlags&ScriptBip16 == ScriptBip16 && isScriptHash(pops)) {
+		return getSigOpCount(pops, true, scriptFlags)
 	}
 
 	// The public key script is a pay-to-script-hash, so parse the signature
@@ -692,7 +692,7 @@ func GetPreciseSigOpCount(scriptSig, scriptPubKey []byte, bip16 bool, magneticAn
 	// dictate signature operations are counted up to the first parse
 	// failure.
 	shPops, _ := parseScript(shScript)
-	return getSigOpCount(shPops, true, magneticAnomalyActive)
+	return getSigOpCount(shPops, true, scriptFlags)
 }
 
 // IsUnspendable returns whether the passed public key script is unspendable, or

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -614,7 +614,7 @@ func getSigOpCount(pops []parsedOpcode, precise bool, scriptFlags ScriptFlags) i
 		case OP_CHECKDATASIG:
 			fallthrough
 		case OP_CHECKDATASIGVERIFY:
-			if scriptFlags&ScriptVerifyCheckDataSig == ScriptVerifyCheckDataSig {
+			if scriptFlags.HasFlag(ScriptVerifyCheckDataSig) {
 				nSigs++
 			}
 		case OP_CHECKMULTISIG:
@@ -661,7 +661,7 @@ func GetPreciseSigOpCount(scriptSig, scriptPubKey []byte, scriptFlags ScriptFlag
 	pops, _ := parseScript(scriptPubKey)
 
 	// Treat non P2SH transactions as normal.
-	if !(scriptFlags&ScriptBip16 == ScriptBip16 && isScriptHash(pops)) {
+	if !(scriptFlags.HasFlag(ScriptBip16) && isScriptHash(pops)) {
 		return getSigOpCount(pops, true, scriptFlags)
 	}
 

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -3866,8 +3866,14 @@ func TestGetPreciseSigOps(t *testing.T) {
 	// the right pattern.
 	pkScript := mustParseShortForm("HASH160 DATA_20 0x433ec2ac1ffa1b7b7d0" +
 		"27f564529c57197f9ae88 EQUAL")
+
+	var scriptFlags ScriptFlags
+	scriptFlags |= ScriptVerifySigPushOnly |
+		ScriptVerifyCleanStack |
+		ScriptVerifyCheckDataSig | ScriptBip16
+
 	for _, test := range tests {
-		count := GetPreciseSigOpCount(test.scriptSig, pkScript, true, true)
+		count := GetPreciseSigOpCount(test.scriptSig, pkScript, scriptFlags)
 		if count != test.nSigOps {
 			t.Errorf("%s: expected count of %d, got %d", test.name,
 				test.nSigOps, count)

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -260,7 +260,7 @@ func CalcScriptInfo(sigScript, pkScript []byte, scriptFlags ScriptFlags) (*Scrip
 
 	switch {
 	// Count sigops taking into account pay-to-script-hash.
-	case si.PkScriptClass == ScriptHashTy && scriptFlags&ScriptBip16 == ScriptBip16:
+	case si.PkScriptClass == ScriptHashTy && scriptFlags.HasFlag(ScriptBip16):
 		// The pay-to-hash-script is the final data push of the
 		// signature script.
 		script := sigPops[len(sigPops)-1].data

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -234,7 +234,7 @@ type ScriptInfo struct {
 // pair.  It will error if the pair is in someway invalid such that they can not
 // be analysed, i.e. if they do not parse or the pkScript is not a push-only
 // script
-func CalcScriptInfo(sigScript, pkScript []byte, bip16 bool, magneticAnomalyActive bool) (*ScriptInfo, error) {
+func CalcScriptInfo(sigScript, pkScript []byte, scriptFlags ScriptFlags) (*ScriptInfo, error) {
 
 	sigPops, err := parseScript(sigScript)
 	if err != nil {
@@ -260,7 +260,7 @@ func CalcScriptInfo(sigScript, pkScript []byte, bip16 bool, magneticAnomalyActiv
 
 	switch {
 	// Count sigops taking into account pay-to-script-hash.
-	case si.PkScriptClass == ScriptHashTy && bip16:
+	case si.PkScriptClass == ScriptHashTy && scriptFlags&ScriptBip16 == ScriptBip16:
 		// The pay-to-hash-script is the final data push of the
 		// signature script.
 		script := sigPops[len(sigPops)-1].data
@@ -275,14 +275,14 @@ func CalcScriptInfo(sigScript, pkScript []byte, bip16 bool, magneticAnomalyActiv
 		} else {
 			si.ExpectedInputs += shInputs
 		}
-		si.SigOps = getSigOpCount(shPops, true, magneticAnomalyActive)
+		si.SigOps = getSigOpCount(shPops, true, scriptFlags)
 
 		// All entries pushed to stack (or are OP_RESERVED and exec
 		// will fail).
 		si.NumInputs = len(sigPops)
 
 	default:
-		si.SigOps = getSigOpCount(pkPops, true, magneticAnomalyActive)
+		si.SigOps = getSigOpCount(pkPops, true, scriptFlags)
 
 		// All entries pushed to stack (or are OP_RESERVED and exec
 		// will fail).

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -464,7 +464,16 @@ func TestCalcScriptInfo(t *testing.T) {
 		sigScript := mustParseShortForm(test.sigScript)
 		pkScript := mustParseShortForm(test.pkScript)
 
-		si, err := CalcScriptInfo(sigScript, pkScript, test.bip16, true)
+		var scriptFlags ScriptFlags
+		scriptFlags |= ScriptVerifySigPushOnly |
+			ScriptVerifyCleanStack |
+			ScriptVerifyCheckDataSig
+
+		if test.bip16 {
+			scriptFlags |= ScriptBip16
+		}
+
+		si, err := CalcScriptInfo(sigScript, pkScript, scriptFlags)
 		if e := tstCheckScriptError(err, test.scriptInfoErr); e != nil {
 			t.Errorf("scriptinfo test %q: %v", test.name, e)
 			continue


### PR DESCRIPTION
This resolves the code debt introduced by passing the magneticAnomalyActive bool around instead of the current ScriptFlags set. This should be much cleaner to maintain for future hard forks.