### PR TITLE
[Chore] Be consistent, bump to beta2 in bchd

### DIFF
--- a/version.go
+++ b/version.go
@@ -22,7 +22,7 @@ const (
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	appPreRelease = "beta"
+	appPreRelease = "beta2"
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
We only changed `bchctl` before. This bumps the main bchd to beta2.