### PR TITLE
[Fix] Disconnect peers with malformed messages immediately

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1339,15 +1339,17 @@ out:
 					log.Errorf(errMsg)
 				}
 
-				// Push a reject message for the malformed message and wait for
-				// the message to be sent before disconnecting.
+				// Push a reject message for the malformed message and disconnect
+				// from the peer immediately to prevent sync issues.
 				//
-				// NOTE: Ideally this would include the command in the header if
+				// Ideally this would include the command in the header if
 				// at least that much of the message was valid, but that is not
 				// currently exposed by wire, so just used malformed for the
 				// command.
 				p.PushRejectMsg("malformed", wire.RejectMalformed, errMsg, nil,
 					true)
+
+				p.Disconnect()
 			}
 			break out
 		}


### PR DESCRIPTION
This is just a fix from https://github.com/btcsuite/btcd/pull/1144 to address stalled syncing that I was experiencing. I can confirm it is far more stable for me now.