### PR TITLE
[Feature] Prevent writes when disk space is limited

### DIFF
--- a/database/error.go
+++ b/database/error.go
@@ -62,6 +62,11 @@ const (
 	// the database was attempted against a read-only transaction.
 	ErrTxNotWritable
 
+	// ErrAvailableDiskSpace indicates that the user is running out of
+	// disk space.  The database preventively decided to not allow the
+	// transaction to prevent causing hard-to-detect problems.
+	ErrAvailableDiskSpace
+
 	// **************************************
 	// Errors related to metadata operations.
 	// **************************************
@@ -143,6 +148,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrCorruption:         "ErrCorruption",
 	ErrTxClosed:           "ErrTxClosed",
 	ErrTxNotWritable:      "ErrTxNotWritable",
+	ErrAvailableDiskSpace: "ErrAvailableDiskSpace",
 	ErrBucketNotFound:     "ErrBucketNotFound",
 	ErrBucketExists:       "ErrBucketExists",
 	ErrBucketNameRequired: "ErrBucketNameRequired",

--- a/database/error_test.go
+++ b/database/error_test.go
@@ -27,6 +27,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{database.ErrCorruption, "ErrCorruption"},
 		{database.ErrTxClosed, "ErrTxClosed"},
 		{database.ErrTxNotWritable, "ErrTxNotWritable"},
+		{database.ErrAvailableDiskSpace, "ErrAvailableDiskSpace"},
 		{database.ErrBucketNotFound, "ErrBucketNotFound"},
 		{database.ErrBucketExists, "ErrBucketExists"},
 		{database.ErrBucketNameRequired, "ErrBucketNameRequired"},

--- a/database/ffldb/db.go
+++ b/database/ffldb/db.go
@@ -43,6 +43,13 @@ const (
 	// The serialized block index row format is:
 	//   <blocklocation><blockheader>
 	blockHdrOffset = blockLocSize
+
+	// bytesMiB is the number of bytes in a mebibyte.
+	bytesMiB = 1024 * 1024
+
+	// minAvailableSpaceUpdate is the minimum space available (in bytes) to
+	// allow a write transaction.  The value is 25 MiB.
+	minAvailableSpaceUpdate = 25 * bytesMiB
 )
 
 var (
@@ -1752,6 +1759,23 @@ func (db *db) Type() string {
 // which is used by the managed transaction code while the database method
 // returns the interface.
 func (db *db) begin(writable bool) (*transaction, error) {
+	// Make sure there is enough available disk space so we can inform the
+	// user of the problem instead of causing a db failure.
+	if writable {
+		freeSpace, err := getAvailableDiskSpace()
+		if err != nil {
+			return nil, makeDbErr(database.ErrDriverSpecific,
+				"failed to inspect available disk space", err)
+		}
+
+		if freeSpace < minAvailableSpaceUpdate {
+			errMsg := fmt.Sprintf("available disk space too low: "+
+				"%.1f MiB", float64(freeSpace)/float64(bytesMiB))
+			return nil, makeDbErr(database.ErrAvailableDiskSpace,
+				errMsg, nil)
+		}
+	}
+
 	// Whenever a new writable transaction is started, grab the write lock
 	// to ensure only a single write transaction can be active at the same
 	// time.  This lock will not be released until the transaction is

--- a/database/ffldb/disk.go
+++ b/database/ffldb/disk.go
@@ -1,0 +1,15 @@
+// +build solaris plan9 netbsd openbsd
+
+// Copyright (c) 2013-2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ffldb
+
+// getAvailableDiskSpace is simply a stub that returns
+// 1 byte greater than the disk space that prevents writes.
+// Unfortunately there is not a good way to get the current
+// disk space on these platforms in Go at this time.
+func getAvailableDiskSpace() (uint64, error) {
+	return minAvailableSpaceUpdate + 1, nil
+}

--- a/database/ffldb/disk_darwin.go
+++ b/database/ffldb/disk_darwin.go
@@ -1,0 +1,26 @@
+// +build darwin
+
+// Copyright (c) 2013-2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ffldb
+
+import (
+	"os"
+	"syscall"
+)
+
+// getAvailableDiskSpace returns the number of bytes of available disk space.
+func getAvailableDiskSpace() (uint64, error) {
+	var stat syscall.Statfs_t
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return 0, err
+	}
+
+	syscall.Statfs(wd, &stat)
+
+	return stat.Bavail * uint64(stat.Bsize), nil
+}

--- a/database/ffldb/disk_dragonfly.go
+++ b/database/ffldb/disk_dragonfly.go
@@ -1,0 +1,26 @@
+// +build dragonfly
+
+// Copyright (c) 2013-2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ffldb
+
+import (
+	"os"
+	"syscall"
+)
+
+// getAvailableDiskSpace returns the number of bytes of available disk space.
+func getAvailableDiskSpace() (uint64, error) {
+	var stat syscall.Statfs_t
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return 0, err
+	}
+
+	syscall.Statfs(wd, &stat)
+
+	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
+}

--- a/database/ffldb/disk_freebsd.go
+++ b/database/ffldb/disk_freebsd.go
@@ -1,0 +1,26 @@
+// +build freebsd
+
+// Copyright (c) 2013-2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ffldb
+
+import (
+	"os"
+	"syscall"
+)
+
+// getAvailableDiskSpace returns the number of bytes of available disk space.
+func getAvailableDiskSpace() (uint64, error) {
+	var stat syscall.Statfs_t
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return 0, err
+	}
+
+	syscall.Statfs(wd, &stat)
+
+	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
+}

--- a/database/ffldb/disk_linux.go
+++ b/database/ffldb/disk_linux.go
@@ -1,0 +1,26 @@
+// +build linux
+
+// Copyright (c) 2013-2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ffldb
+
+import (
+	"os"
+	"syscall"
+)
+
+// getAvailableDiskSpace returns the number of bytes of available disk space.
+func getAvailableDiskSpace() (uint64, error) {
+	var stat syscall.Statfs_t
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return 0, err
+	}
+
+	syscall.Statfs(wd, &stat)
+
+	return stat.Bavail * uint64(stat.Bsize), nil
+}

--- a/database/ffldb/disk_windows.go
+++ b/database/ffldb/disk_windows.go
@@ -1,0 +1,33 @@
+// +build windows
+
+// Copyright (c) 2013-2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ffldb
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// getAvailableDiskSpace returns the number of bytes of available disk space.
+func getAvailableDiskSpace() (uint64, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return 0, err
+	}
+
+	h := syscall.MustLoadDLL("kernel32.dll")
+	c := h.MustFindProc("GetDiskFreeSpaceExW")
+
+	var freeBytes, totalBytes, availBytes int64
+	_, _, err = c.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(wd))),
+		uintptr(unsafe.Pointer(&freeBytes)), uintptr(unsafe.Pointer(&totalBytes)), uintptr(unsafe.Pointer(&availBytes)))
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(freeBytes), nil
+}


### PR DESCRIPTION
Prevents writes when the disk is low on space.

Currently supports:
- darwin
- linux
- windows
- freebsd
- dragonfly

Other platforms have a stub that always allows writes. Go doesn't have a good way to calculate disk space on these platforms due to limitations in the syscall package.

Based off the work done in https://github.com/btcsuite/btcd/pull/1156

NOTE: Right now I don't think this supports mounted disks for the data dir. I will amend this to support that case in a follow up PR.