### PR TITLE
[Fix] Check disk space at the level db store path

### DIFF
--- a/database/ffldb/db.go
+++ b/database/ffldb/db.go
@@ -1762,7 +1762,7 @@ func (db *db) begin(writable bool) (*transaction, error) {
 	// Make sure there is enough available disk space so we can inform the
 	// user of the problem instead of causing a db failure.
 	if writable {
-		freeSpace, err := getAvailableDiskSpace()
+		freeSpace, err := getAvailableDiskSpace(db.store.basePath)
 		if err != nil {
 			return nil, makeDbErr(database.ErrDriverSpecific,
 				"failed to inspect available disk space", err)

--- a/database/ffldb/disk.go
+++ b/database/ffldb/disk.go
@@ -10,6 +10,6 @@ package ffldb
 // 1 byte greater than the disk space that prevents writes.
 // Unfortunately there is not a good way to get the current
 // disk space on these platforms in Go at this time.
-func getAvailableDiskSpace() (uint64, error) {
+func getAvailableDiskSpace(path string) (uint64, error) {
 	return minAvailableSpaceUpdate + 1, nil
 }

--- a/database/ffldb/disk_darwin.go
+++ b/database/ffldb/disk_darwin.go
@@ -7,20 +7,14 @@
 package ffldb
 
 import (
-	"os"
 	"syscall"
 )
 
 // getAvailableDiskSpace returns the number of bytes of available disk space.
-func getAvailableDiskSpace() (uint64, error) {
+func getAvailableDiskSpace(path string) (uint64, error) {
 	var stat syscall.Statfs_t
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return 0, err
-	}
-
-	syscall.Statfs(wd, &stat)
+	syscall.Statfs(path, &stat)
 
 	return stat.Bavail * uint64(stat.Bsize), nil
 }

--- a/database/ffldb/disk_dragonfly.go
+++ b/database/ffldb/disk_dragonfly.go
@@ -7,20 +7,14 @@
 package ffldb
 
 import (
-	"os"
 	"syscall"
 )
 
 // getAvailableDiskSpace returns the number of bytes of available disk space.
-func getAvailableDiskSpace() (uint64, error) {
+func getAvailableDiskSpace(path string) (uint64, error) {
 	var stat syscall.Statfs_t
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return 0, err
-	}
-
-	syscall.Statfs(wd, &stat)
+	syscall.Statfs(path, &stat)
 
 	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
 }

--- a/database/ffldb/disk_freebsd.go
+++ b/database/ffldb/disk_freebsd.go
@@ -7,20 +7,14 @@
 package ffldb
 
 import (
-	"os"
 	"syscall"
 )
 
 // getAvailableDiskSpace returns the number of bytes of available disk space.
-func getAvailableDiskSpace() (uint64, error) {
+func getAvailableDiskSpace(path string) (uint64, error) {
 	var stat syscall.Statfs_t
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return 0, err
-	}
-
-	syscall.Statfs(wd, &stat)
+	syscall.Statfs(path, &stat)
 
 	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
 }

--- a/database/ffldb/disk_linux.go
+++ b/database/ffldb/disk_linux.go
@@ -7,20 +7,14 @@
 package ffldb
 
 import (
-	"os"
 	"syscall"
 )
 
 // getAvailableDiskSpace returns the number of bytes of available disk space.
-func getAvailableDiskSpace() (uint64, error) {
+func getAvailableDiskSpace(path string) (uint64, error) {
 	var stat syscall.Statfs_t
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return 0, err
-	}
-
-	syscall.Statfs(wd, &stat)
+	syscall.Statfs(path, &stat)
 
 	return stat.Bavail * uint64(stat.Bsize), nil
 }

--- a/database/ffldb/disk_windows.go
+++ b/database/ffldb/disk_windows.go
@@ -7,23 +7,17 @@
 package ffldb
 
 import (
-	"os"
 	"syscall"
 	"unsafe"
 )
 
 // getAvailableDiskSpace returns the number of bytes of available disk space.
-func getAvailableDiskSpace() (uint64, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return 0, err
-	}
-
+func getAvailableDiskSpace(path string) (uint64, error) {
 	h := syscall.MustLoadDLL("kernel32.dll")
 	c := h.MustFindProc("GetDiskFreeSpaceExW")
 
 	var freeBytes, totalBytes, availBytes int64
-	_, _, err = c.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(wd))),
+	_, _, err := c.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))),
 		uintptr(unsafe.Pointer(&freeBytes)), uintptr(unsafe.Pointer(&totalBytes)), uintptr(unsafe.Pointer(&availBytes)))
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Update the disk space checks to the location of the leveldb storage. This should now support mounted volumes for the data dir.