### PR TITLE
[Fix] Validate PKCS7 padding correctly

### DIFF
--- a/bchec/ciphering_test.go
+++ b/bchec/ciphering_test.go
@@ -162,8 +162,35 @@ func TestCipheringErrors(t *testing.T) {
 	tests2 := []struct {
 		in []byte // input data
 	}{
+		// too long
 		{bytes.Repeat([]byte{0x11}, 17)},
+		// too short
 		{bytes.Repeat([]byte{0x07}, 15)},
+		// invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 15),
+			bytes.Repeat([]byte{0x04}, 1)...)},
+		// invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 9),
+			[]byte{0x01, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07}...)},
+		// invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 9),
+			[]byte{0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0xfe, 0x10,
+				0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10}...)},
+		// invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 9),
+			[]byte{0x01, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07}...)},
+		// invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 9),
+			[]byte{0x01, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07}...)},
+		// invalid padding length
+		{append(bytes.Repeat([]byte{0x07}, 15),
+			bytes.Repeat([]byte{0x11}, 1)...)},
+		// invalid padding length
+		{append(bytes.Repeat([]byte{0x07}, 15),
+			bytes.Repeat([]byte{0x00}, 1)...)},
+		// invalid padding length
+		{append(bytes.Repeat([]byte{0x07}, 15),
+			bytes.Repeat([]byte{0xff}, 1)...)},
 	}
 	for i, test := range tests2 {
 		_, err = removePKCSPadding(test.in)


### PR DESCRIPTION
Thanks to @AdamISZ for the fix found at https://github.com/btcsuite/btcd/pull/1108

This just makes sure we follow RFC2315.