### PR TITLE
[Fix] Add omitempty to Hex field of TxRawResult

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -442,7 +442,7 @@ type InfoChainResult struct {
 
 // TxRawResult models the data from the getrawtransaction command.
 type TxRawResult struct {
-	Hex           string `json:"hex"`
+	Hex           string `json:"hex,omitempty"`
 	Txid          string `json:"txid"`
 	Hash          string `json:"hash,omitempty"`
 	Size          int32  `json:"size,omitempty"`


### PR DESCRIPTION
There are cases where the hex field is empty and returns an empty string. Better to just not include the key if it is nil.

Pulled from https://github.com/btcsuite/btcd/pull/1131