### PR TITLE
[Feature] Add SubtractFeeFromAmount params to SendToAddressCmd

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -507,10 +507,11 @@ func NewSendManyCmd(fromAccount string, amounts map[string]float64, minConf *int
 
 // SendToAddressCmd defines the sendtoaddress JSON-RPC command.
 type SendToAddressCmd struct {
-	Address   string
-	Amount    float64
-	Comment   *string
-	CommentTo *string
+	Address               string
+	Amount                float64
+	Comment               *string
+	CommentTo             *string
+	SubtractFeeFromAmount *bool
 }
 
 // NewSendToAddressCmd returns a new instance which can be used to issue a
@@ -518,12 +519,13 @@ type SendToAddressCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewSendToAddressCmd(address string, amount float64, comment, commentTo *string) *SendToAddressCmd {
+func NewSendToAddressCmd(address string, amount float64, comment, commentTo *string, subtractFeeFromAmount *bool) *SendToAddressCmd {
 	return &SendToAddressCmd{
-		Address:   address,
-		Amount:    amount,
-		Comment:   comment,
-		CommentTo: commentTo,
+		Address:               address,
+		Amount:                amount,
+		Comment:               comment,
+		CommentTo:             commentTo,
+		SubtractFeeFromAmount: subtractFeeFromAmount,
 	}
 }
 

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -999,31 +999,33 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("sendtoaddress", "1Address", 0.5)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewSendToAddressCmd("1Address", 0.5, nil, nil)
+				return btcjson.NewSendToAddressCmd("1Address", 0.5, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"sendtoaddress","params":["1Address",0.5],"id":1}`,
 			unmarshalled: &btcjson.SendToAddressCmd{
-				Address:   "1Address",
-				Amount:    0.5,
-				Comment:   nil,
-				CommentTo: nil,
+				Address:               "1Address",
+				Amount:                0.5,
+				Comment:               nil,
+				CommentTo:             nil,
+				SubtractFeeFromAmount: nil,
 			},
 		},
 		{
 			name: "sendtoaddress optional1",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("sendtoaddress", "1Address", 0.5, "comment", "commentto")
+				return btcjson.NewCmd("sendtoaddress", "1Address", 0.5, "comment", "commentto", true)
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSendToAddressCmd("1Address", 0.5, btcjson.String("comment"),
-					btcjson.String("commentto"))
+					btcjson.String("commentto"), btcjson.Bool(true))
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"sendtoaddress","params":["1Address",0.5,"comment","commentto"],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"sendtoaddress","params":["1Address",0.5,"comment","commentto",true],"id":1}`,
 			unmarshalled: &btcjson.SendToAddressCmd{
-				Address:   "1Address",
-				Amount:    0.5,
-				Comment:   btcjson.String("comment"),
-				CommentTo: btcjson.String("commentto"),
+				Address:               "1Address",
+				Amount:                0.5,
+				Comment:               btcjson.String("comment"),
+				CommentTo:             btcjson.String("commentto"),
+				SubtractFeeFromAmount: btcjson.Bool(true),
 			},
 		},
 		{

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -471,7 +471,7 @@ func (r FutureSendToAddressResult) Receive() (*chainhash.Hash, error) {
 // See SendToAddress for the blocking version and more details.
 func (c *Client) SendToAddressAsync(address bchutil.Address, amount bchutil.Amount) FutureSendToAddressResult {
 	addr := address.EncodeAddress()
-	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBCH(), nil, nil)
+	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBCH(), nil, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -498,7 +498,7 @@ func (c *Client) SendToAddressCommentAsync(address bchutil.Address,
 
 	addr := address.EncodeAddress()
 	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBCH(), &comment,
-		&commentTo)
+		&commentTo, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -517,6 +517,37 @@ func (c *Client) SendToAddressCommentAsync(address bchutil.Address,
 func (c *Client) SendToAddressComment(address bchutil.Address, amount bchutil.Amount, comment, commentTo string) (*chainhash.Hash, error) {
 	return c.SendToAddressCommentAsync(address, amount, comment,
 		commentTo).Receive()
+}
+
+// SendToAddressCommentSubFeeAsync returns an instance of a type that can be used to
+// get the result of the RPC at some future time by invoking the Receive
+// function on the returned instance.
+//
+// See SendToAddressCommentSubFee for the blocking version and more details.
+func (c *Client) SendToAddressCommentSubFeeAsync(address bchutil.Address, amount bchutil.Amount, comment, commentTo string, subtractFeeFromAmount bool) FutureSendToAddressResult {
+	addr := address.EncodeAddress()
+	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBCH(), &comment, &commentTo, &subtractFeeFromAmount)
+
+	return c.sendCmd(cmd)
+}
+
+// SendToAddressCommentSubFee sends the passed amount to the given address and stores
+// the provided comment and comment to in the wallet. The fee is subtracted from the amount.
+// The comment parameter is intended to be used for the purpose of the transaction while the commentTo
+// parameter is indended to be used for who the transaction is being sent to.
+//
+// The comments are not part of the transaction and are only internal
+// to the wallet.
+//
+// The transaction fee is subtracted from the amount.
+//
+// See SendToAddressComment to avoid using subtractFeeFromAmount.
+// See SendToAddress to avoid using comments.
+//
+// NOTE: This function requires to the wallet to be unlocked.  See the
+// WalletPassphrase function for more details.
+func (c *Client) SendToAddressCommentSubFee(address bchutil.Address, amount bchutil.Amount, comment, commentTo string, subtractFeeFromAmount bool) (*chainhash.Hash, error) {
+	return c.SendToAddressCommentSubFeeAsync(address, amount, comment, commentTo, subtractFeeFromAmount).Receive()
 }
 
 // FutureSendFromResult is a future promise to deliver the result of a


### PR DESCRIPTION
Add easy way to send a transaction with the fee removed from the sending amount.

Ported from https://github.com/btcsuite/btcd/pull/1155