### PR TITLE
[Feature] Improve sync node selection algo

### DIFF
--- a/netsync/manager_test.go
+++ b/netsync/manager_test.go
@@ -185,8 +185,8 @@ func TestPeerConnections(t *testing.T) {
 			localNode2.ID())
 	}
 	if syncMgr.SyncPeerID() != localNode2.ID() {
-		t.Fatalf("Expected sync manager to be syncing from peer %d",
-			localNode2.ID())
+		t.Fatalf("Expected sync manager to be syncing from peer %d got %d",
+			localNode2.ID(), syncMgr.SyncPeerID())
 	}
 
 	// Register another full node peer with the manager. Even though the new


### PR DESCRIPTION
This is just a small improvement to the sync node selection. The previous selection was extremely poor, and merely grabbed the last possible candidate (the last one that connected). This caused the selection to be limited and I believe is the culprit behind the long stalls I have seen.

The new algo is simple but should improve things.

1) Look for a peer at a higher block height, then randomly select one of them.
2) If there are no peers at a higher block height, allow a connection to the same block height. This mirrors what happens today but makes this case merely a fallback.

In testing this is working well. I have not seen a stall with this patch.