### PR TITLE
Update DAAForkHeight for Simnet params

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -520,7 +520,7 @@ var SimNetParams = Params{
 	BIP0065Height:                 0, // Always active on simnet
 	BIP0066Height:                 0, // Always active on simnet
 	UahfForkHeight:                0, // Always active on simnet
-	DaaForkHeight:                 0, // Always active on simnet
+	DaaForkHeight:                 500,
 	MagneticAnomalyActivationTime: 1542300000,
 	CoinbaseMaturity:              100,
 	SubsidyReductionInterval:      210000,


### PR DESCRIPTION
Neutrino is using simnet and barfing on the difficulty adjustment since you need historical blocks to calculate the difficulty and you don't have any at the beginning of the chain. Actually not sure why bchd isn't having an issue with this on simnet and regtest right now, but the easiest path is to just make the DAA activate later. 

If I figure out how to calculate the DAA early in the chain maybe I can switch it back. 