### PR TITLE
[Chore] Add seed.bchd.cash to the seed list

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -232,12 +232,12 @@ var MainNetParams = Params{
 	Net:         wire.MainNet,
 	DefaultPort: "8333",
 	DNSSeeds: []DNSSeed{
+		{"seed.bchd.cash", true},
 		{"seed.bitcoinabc.org", true},
 		{"seed-abc.bitcoinforks.org", true},
 		{"btccash-seeder.bitcoinunlimited.info", true},
 		{"seed.bitprim.org", true},
 		{"seed.deadalnix.me", true},
-		{"seeder.criptolayer.net", true},
 	},
 
 	// Chain parameters

--- a/chaincfg/params_test.go
+++ b/chaincfg/params_test.go
@@ -33,3 +33,32 @@ func TestMustRegisterPanic(t *testing.T) {
 	// Intentionally try to register duplicate params to force a panic.
 	mustRegister(&MainNetParams)
 }
+
+// TestSeeds ensures the right seeds are defined.
+func TestSeeds(t *testing.T) {
+	expectedSeeds := []DNSSeed{
+		{"seed.bchd.cash", true},
+		{"seed.bitcoinabc.org", true},
+		{"seed-abc.bitcoinforks.org", true},
+		{"btccash-seeder.bitcoinunlimited.info", true},
+		{"seed.bitprim.org", true},
+		{"seed.deadalnix.me", true},
+	}
+
+	if MainNetParams.DNSSeeds == nil {
+		t.Error("Seed values are not set")
+		return
+	}
+
+	if len(MainNetParams.DNSSeeds) != len(expectedSeeds) {
+		t.Error("Incorrect number of seed values")
+		return
+	}
+
+	for i := range MainNetParams.DNSSeeds {
+		if MainNetParams.DNSSeeds[i] != expectedSeeds[i] {
+			t.Error("Seed values are incorrect")
+			return
+		}
+	}
+}

--- a/kube/bchd-deployment.yml
+++ b/kube/bchd-deployment.yml
@@ -4,7 +4,7 @@ metadata:
   namespace: default
   labels:
     service: bchd
-    version: 0.12.0-beta
+    version: 0.12.0-beta2
   name: bchd
 spec:
   strategy:


### PR DESCRIPTION
Adds `seed.bchd.cash` to our default seeds and removed `seeder.criptolayer.net` which was unreliable. Also back-filled some very basic tests.