### PR TITLE
[Fix] Improve reliablity of peer test

### DIFF
--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -186,23 +186,27 @@ func testPeer(t *testing.T, p *peer.Peer, s peerStats) {
 		return
 	}
 
+	// These tests are inherently racy. Call the snapshot
+	// right before testing the values!
 	stats := p.StatsSnapshot()
-
 	if p.ID() != stats.ID {
 		t.Errorf("testPeer: wrong ID - got %v, want %v", p.ID(), stats.ID)
 		return
 	}
 
+	stats = p.StatsSnapshot()
 	if p.Addr() != stats.Addr {
 		t.Errorf("testPeer: wrong Addr - got %v, want %v", p.Addr(), stats.Addr)
 		return
 	}
 
+	stats = p.StatsSnapshot()
 	if p.LastSend() != stats.LastSend {
 		t.Errorf("testPeer: wrong LastSend - got %v, want %v", p.LastSend(), stats.LastSend)
 		return
 	}
 
+	stats = p.StatsSnapshot()
 	if p.LastRecv() != stats.LastRecv {
 		t.Errorf("testPeer: wrong LastRecv - got %v, want %v", p.LastRecv(), stats.LastRecv)
 		return


### PR DESCRIPTION
Unfortunately there is a race condition in the peer tests. I had a few failures on unrelated changes and figured I would reduce the race condition window. Unfortunately this doesn't completely fix the issue, but is more reliable in my testing.

Basically there is a race condition between when the snapshot is taken, and the values becoming stale. To address this, I just take the snapshot right before each comparison. Not great but I don't see a better way.