### PR TITLE
[Fix] Update sync peer when no blocks are received

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -507,6 +507,9 @@ func (sm *SyncManager) clearRequestedState(state *peerSyncState) {
 func (sm *SyncManager) updateSyncPeer(state *peerSyncState) {
 	log.Infof("Updating sync peer, no blocks since: %v", sm.LastBlockTime())
 
+	// Disconnect from the misbehaving peer.
+	sm.syncPeer.Disconnect()
+
 	// Attempt to find a new peer to sync from
 	// Also, reset the headers-first state.
 	sm.syncPeer.SetSyncPeer(false)

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -43,11 +43,11 @@ const (
 	// maxLastBlockTime is the longest time in seconds that we will
 	// stay with a sync peer while below the current blockchain height.
 	// Set to 3 minutes.
-	maxLastBlockTime = 60 * 3
+	maxLastBlockTime = 60 * 3 * time.Second
 
 	// lastBlockTimeTickerInterval is how often we check the current
 	// syncPeer. Set to 30 seconds.
-	lastBlockTimeTickerInterval = 30
+	lastBlockTimeTickerInterval = 30 * time.Second
 )
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
@@ -412,7 +412,7 @@ func (sm *SyncManager) handleNewSyncPeerMsg() {
 	log.Debugf("Checking Sync Peer, time since last block: %v", sm.lastBlockTime)
 
 	// Do nothing if we haven't hit our time threshold.
-	if time.Since(sm.lastBlockTime) <= maxLastBlockTime*time.Second {
+	if time.Since(sm.lastBlockTime) <= maxLastBlockTime {
 		return
 	}
 
@@ -1228,7 +1228,7 @@ func (sm *SyncManager) limitMap(m map[chainhash.Hash]struct{}, limit int) {
 // important because the sync manager controls which blocks are needed and how
 // the fetching should proceed.
 func (sm *SyncManager) blockHandler() {
-	ticker := time.NewTicker(time.Second * lastBlockTimeTickerInterval)
+	ticker := time.NewTicker(lastBlockTimeTickerInterval)
 	defer ticker.Stop()
 
 out:

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -395,8 +395,6 @@ func (sm *SyncManager) handleCheckSyncPeer() {
 		return
 	}
 
-	log.Debugf("Checking Sync Peer, time since last block: %v", sm.lastBlockTime)
-
 	// Do nothing if we haven't hit our time threshold.
 	if time.Since(sm.lastBlockTime) <= maxLastBlockTime {
 		return
@@ -450,7 +448,7 @@ func (sm *SyncManager) handleDonePeerMsg(peer *peerpkg.Peer) {
 	}
 }
 
-// updateRequestedState removes requested transactions
+// clearRequestedState removes requested transactions
 // and blocks from the global map.
 func (sm *SyncManager) clearRequestedState(state *peerSyncState) {
 	// Remove requested transactions from the global map so that they will

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1247,7 +1247,9 @@ func (sm *SyncManager) limitMap(m map[chainhash.Hash]struct{}, limit int) {
 // important because the sync manager controls which blocks are needed and how
 // the fetching should proceed.
 func (sm *SyncManager) blockHandler() {
-	go sm.lastBlockTimeTicker(lastBlockTimeTickerInterval * time.Second)
+	ticker := time.NewTicker(time.Second * lastBlockTimeTickerInterval)
+	defer ticker.Stop()
+	go sm.lastBlockTimeTicker(ticker)
 
 out:
 	for {
@@ -1597,8 +1599,7 @@ func New(config *Config) (*SyncManager, error) {
 	return &sm, nil
 }
 
-func (sm *SyncManager) lastBlockTimeTicker(d time.Duration) {
-	ticker := time.NewTicker(d)
+func (sm *SyncManager) lastBlockTimeTicker(ticker *time.Ticker) {
 	for range ticker.C {
 		log.Debugf("Checking Sync Peer, time since last block: %v", sm.LastBlockTime())
 

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -172,8 +172,8 @@ type SyncManager struct {
 	requestedTxns   map[chainhash.Hash]struct{}
 	requestedBlocks map[chainhash.Hash]struct{}
 
-	syncPeer      *peerpkg.Peer
-	peerStates    map[*peerpkg.Peer]*peerSyncState
+	syncPeer   *peerpkg.Peer
+	peerStates map[*peerpkg.Peer]*peerSyncState
 
 	// The following fields are used for headers-first mode.
 	headersFirstMode bool
@@ -185,7 +185,7 @@ type SyncManager struct {
 	feeEstimator *mempool.FeeEstimator
 
 	// The last time we processed an unorphaned block.
-	lastBlockTime      time.Time
+	lastBlockTime time.Time
 }
 
 // resetHeaderState sets the headers-first mode state to values appropriate for
@@ -1199,7 +1199,7 @@ func (sm *SyncManager) blockHandler() {
 out:
 	for {
 		select {
-		case  <- ticker.C:
+		case <-ticker.C:
 			sm.handleCheckSyncPeer()
 		case m := <-sm.msgChan:
 			switch msg := m.(type) {

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -515,6 +515,9 @@ func (sm *SyncManager) updateSyncPeer(state *peerSyncState) {
 	sm.syncPeer.SetSyncPeer(false)
 	sm.syncPeer = nil
 
+	// Set the last block time to reset the timer.
+	sm.SetLastBlockTime(time.Now())
+
 	if sm.headersFirstMode {
 		best := sm.chain.BestSnapshot()
 		sm.resetHeaderState(&best.Hash, best.Height)

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -411,6 +411,8 @@ func (sm *SyncManager) handleCheckSyncPeer() {
 	// blocks.
 	best := sm.chain.BestSnapshot()
 	if sm.syncPeer.LastBlock() == best.Height {
+		// Update the time to prevent disconnects.
+		sm.lastBlockTime = time.Now()
 		return
 	}
 

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -403,8 +403,8 @@ func (sm *SyncManager) handleNewPeerMsg(peer *peerpkg.Peer) {
 	}
 }
 
-// handleNewSyncPeerMsg selects a new sync peer.
-func (sm *SyncManager) handleNewSyncPeerMsg() {
+// handleCheckSyncPeer selects a new sync peer.
+func (sm *SyncManager) handleCheckSyncPeer() {
 	if atomic.LoadInt32(&sm.shutdown) != 0 {
 		return
 	}
@@ -1235,7 +1235,7 @@ out:
 	for {
 		select {
 		case  <- ticker.C:
-			sm.handleNewSyncPeerMsg()
+			sm.handleCheckSyncPeer()
 		case m := <-sm.msgChan:
 			switch msg := m.(type) {
 			case *newPeerMsg:

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -578,7 +578,7 @@ func (p *Peer) ID() int32 {
 func (p *Peer) SyncPeer() bool {
 	p.flagsMtx.Lock()
 	sp := p.syncPeer
-	defer p.flagsMtx.Unlock()
+	p.flagsMtx.Unlock()
 
 	return sp
 }


### PR DESCRIPTION
This PR fixes the stalled syncing issue when a node stops broadcasting blocks. It does NOT fix the slow peer issue, that will be saved for a future PR.

The general idea is we have a timer that runs every 30 seconds. If no block is found in 3 minutes and we are still below the chain height then we select a new sync peer. If we are at the current block we happily stay with the sync peer we currently have.

I tested this by firewalling off the connection to my current sync peer. It then successfully switched nodes and jumped to a new peer.

Note I removed the syncPeerMutex, as I realized it is not needed. Everything goes through blockHandler which maintains synchronization. Learning more about the code every day. =)

Let me know what you think.

Thanks to @eyeamera for the thorough review. =)