### PR TITLE
[Feature] Add slow sync peer detection

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,33 +34,34 @@ import (
 )
 
 const (
-	defaultConfigFilename        = "bchd.conf"
-	defaultDataDirname           = "data"
-	defaultLogLevel              = "info"
-	defaultLogDirname            = "logs"
-	defaultLogFilename           = "bchd.log"
-	defaultMaxPeers              = 125
-	defaultMaxPeersPerIP         = 5
-	defaultBanDuration           = time.Hour * 24
-	defaultBanThreshold          = 100
-	defaultConnectTimeout        = time.Second * 30
-	defaultMaxRPCClients         = 10
-	defaultMaxRPCWebsockets      = 25
-	defaultMaxRPCConcurrentReqs  = 20
-	defaultDbType                = "ffldb"
-	defaultFreeTxRelayLimit      = 15.0
-	defaultTrickleInterval       = peer.DefaultTrickleInterval
-	defaultExcessiveBlockSize    = 32000000
-	defaultBlockMinSize          = 0
-	defaultBlockMaxSize          = 750000
-	blockMaxSizeMin              = 1000
-	blockMaxSizeMax              = defaultExcessiveBlockSize - 1000
-	defaultGenerate              = false
-	defaultMaxOrphanTransactions = 100
-	defaultMaxOrphanTxSize       = 100000
-	defaultSigCacheMaxSize       = 100000
-	defaultTxIndex               = false
-	defaultAddrIndex             = false
+	defaultConfigFilename          = "bchd.conf"
+	defaultDataDirname             = "data"
+	defaultLogLevel                = "info"
+	defaultLogDirname              = "logs"
+	defaultLogFilename             = "bchd.log"
+	defaultMaxPeers                = 125
+	defaultMaxPeersPerIP           = 5
+	defaultBanDuration             = time.Hour * 24
+	defaultBanThreshold            = 100
+	defaultConnectTimeout          = time.Second * 30
+	defaultMaxRPCClients           = 10
+	defaultMaxRPCWebsockets        = 25
+	defaultMaxRPCConcurrentReqs    = 20
+	defaultDbType                  = "ffldb"
+	defaultFreeTxRelayLimit        = 15.0
+	defaultTrickleInterval         = peer.DefaultTrickleInterval
+	defaultExcessiveBlockSize      = 32000000
+	defaultBlockMinSize            = 0
+	defaultBlockMaxSize            = 750000
+	blockMaxSizeMin                = 1000
+	blockMaxSizeMax                = defaultExcessiveBlockSize - 1000
+	defaultGenerate                = false
+	defaultMaxOrphanTransactions   = 100
+	defaultMaxOrphanTxSize         = 100000
+	defaultSigCacheMaxSize         = 100000
+	defaultTxIndex                 = false
+	defaultAddrIndex               = false
+	defaultMinSyncPeerNetworkSpeed = 51200
 )
 
 var (
@@ -99,84 +100,85 @@ func maxUint32(a, b uint32) uint32 {
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
-	ShowVersion          bool          `short:"V" long:"version" description:"Display version information and exit"`
-	ConfigFile           string        `short:"C" long:"configfile" description:"Path to configuration file"`
-	DataDir              string        `short:"b" long:"datadir" description:"Directory to store data"`
-	LogDir               string        `long:"logdir" description:"Directory to log output."`
-	AddPeers             []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
-	ConnectPeers         []string      `long:"connect" description:"Connect only to the specified peers at startup"`
-	DisableListen        bool          `long:"nolisten" description:"Disable listening for incoming connections -- NOTE: Listening is automatically disabled if the --connect or --proxy options are used without also specifying listen interfaces via --listen"`
-	Listeners            []string      `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 8333, testnet: 18333)"`
-	MaxPeers             int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
-	MaxPeersPerIP        int           `long:"maxpeersperip" description:"Max number of inbound and outbound peers per IP"`
-	DisableBanning       bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
-	BanDuration          time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
-	BanThreshold         uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
-	Whitelists           []string      `long:"whitelist" description:"Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)"`
-	RPCUser              string        `short:"u" long:"rpcuser" description:"Username for RPC connections"`
-	RPCPass              string        `short:"P" long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
-	RPCLimitUser         string        `long:"rpclimituser" description:"Username for limited RPC connections"`
-	RPCLimitPass         string        `long:"rpclimitpass" default-mask:"-" description:"Password for limited RPC connections"`
-	RPCListeners         []string      `long:"rpclisten" description:"Add an interface/port to listen for RPC connections (default port: 8334, testnet: 18334)"`
-	RPCCert              string        `long:"rpccert" description:"File containing the certificate file"`
-	RPCKey               string        `long:"rpckey" description:"File containing the certificate key"`
-	RPCMaxClients        int           `long:"rpcmaxclients" description:"Max number of RPC clients for standard connections"`
-	RPCMaxWebsockets     int           `long:"rpcmaxwebsockets" description:"Max number of RPC websocket connections"`
-	RPCMaxConcurrentReqs int           `long:"rpcmaxconcurrentreqs" description:"Max number of concurrent RPC requests that may be processed concurrently"`
-	RPCQuirks            bool          `long:"rpcquirks" description:"Mirror some JSON-RPC quirks of Bitcoin Core -- NOTE: Discouraged unless interoperability issues need to be worked around"`
-	DisableRPC           bool          `long:"norpc" description:"Disable built-in RPC server -- NOTE: The RPC server is disabled by default if no rpcuser/rpcpass or rpclimituser/rpclimitpass is specified"`
-	DisableTLS           bool          `long:"notls" description:"Disable TLS for the RPC server -- NOTE: This is only allowed if the RPC server is bound to localhost"`
-	DisableDNSSeed       bool          `long:"nodnsseed" description:"Disable DNS seeding for peers"`
-	ExternalIPs          []string      `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
-	Proxy                string        `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
-	ProxyUser            string        `long:"proxyuser" description:"Username for proxy server"`
-	ProxyPass            string        `long:"proxypass" default-mask:"-" description:"Password for proxy server"`
-	OnionProxy           string        `long:"onion" description:"Connect to tor hidden services via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
-	OnionProxyUser       string        `long:"onionuser" description:"Username for onion proxy server"`
-	OnionProxyPass       string        `long:"onionpass" default-mask:"-" description:"Password for onion proxy server"`
-	NoOnion              bool          `long:"noonion" description:"Disable connecting to tor hidden services"`
-	TorIsolation         bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
-	TestNet3             bool          `long:"testnet" description:"Use the test network"`
-	TestNet1             bool          `long:"testnet1" description:"Use the testnet1 network"`
-	RegressionTest       bool          `long:"regtest" description:"Use the regression test network"`
-	SimNet               bool          `long:"simnet" description:"Use the simulation test network"`
-	AddCheckpoints       []string      `long:"addcheckpoint" description:"Add a custom checkpoint.  Format: '<height>:<hash>'"`
-	DisableCheckpoints   bool          `long:"nocheckpoints" description:"Disable built-in checkpoints.  Don't do this unless you know what you're doing."`
-	DbType               string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
-	Profile              string        `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
-	CPUProfile           string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
-	DebugLevel           string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
-	Upnp                 bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
-	ExcessiveBlockSize   uint32        `long:"excessiveblocksize" description:"The maximum size block (in bytes) this node will accept. Cannot be less than 32000000."`
-	MinRelayTxFee        float64       `long:"minrelaytxfee" description:"The minimum transaction fee in BCH/kB to be considered a non-zero fee."`
-	FreeTxRelayLimit     float64       `long:"limitfreerelay" description:"Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute"`
-	NoRelayPriority      bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
-	TrickleInterval      time.Duration `long:"trickleinterval" description:"Minimum time between attempts to send new inventory to a connected peer"`
-	MaxOrphanTxs         int           `long:"maxorphantx" description:"Max number of orphan transactions to keep in memory"`
-	Generate             bool          `long:"generate" description:"Generate (mine) bitcoins using the CPU"`
-	MiningAddrs          []string      `long:"miningaddr" description:"Add the specified payment address to the list of addresses to use for generated blocks -- At least one address is required if the generate option is set"`
-	BlockMinSize         uint32        `long:"blockminsize" description:"Mininum block size in bytes to be used when creating a block"`
-	BlockMaxSize         uint32        `long:"blockmaxsize" description:"Maximum block size in bytes to be used when creating a block"`
-	BlockPrioritySize    uint32        `long:"blockprioritysize" description:"Size in bytes for high-priority/low-fee transactions when creating a block"`
-	UserAgentComments    []string      `long:"uacomment" description:"Comment to add to the user agent -- See BIP 14 for more information."`
-	NoPeerBloomFilters   bool          `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
-	NoCFilters           bool          `long:"nocfilters" description:"Disable committed filtering (CF) support"`
-	DropCfIndex          bool          `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
-	SigCacheMaxSize      uint          `long:"sigcachemaxsize" description:"The maximum number of entries in the signature verification cache"`
-	BlocksOnly           bool          `long:"blocksonly" description:"Do not accept transactions from remote peers."`
-	TxIndex              bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
-	DropTxIndex          bool          `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
-	AddrIndex            bool          `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
-	DropAddrIndex        bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
-	RelayNonStd          bool          `long:"relaynonstd" description:"Relay non-standard transactions regardless of the default settings for the active network."`
-	RejectNonStd         bool          `long:"rejectnonstd" description:"Reject non-standard transactions regardless of the default settings for the active network."`
-	lookup               func(string) ([]net.IP, error)
-	oniondial            func(string, string, time.Duration) (net.Conn, error)
-	dial                 func(string, string, time.Duration) (net.Conn, error)
-	addCheckpoints       []chaincfg.Checkpoint
-	miningAddrs          []bchutil.Address
-	minRelayTxFee        bchutil.Amount
-	whitelists           []*net.IPNet
+	ShowVersion             bool          `short:"V" long:"version" description:"Display version information and exit"`
+	ConfigFile              string        `short:"C" long:"configfile" description:"Path to configuration file"`
+	DataDir                 string        `short:"b" long:"datadir" description:"Directory to store data"`
+	LogDir                  string        `long:"logdir" description:"Directory to log output."`
+	AddPeers                []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
+	ConnectPeers            []string      `long:"connect" description:"Connect only to the specified peers at startup"`
+	DisableListen           bool          `long:"nolisten" description:"Disable listening for incoming connections -- NOTE: Listening is automatically disabled if the --connect or --proxy options are used without also specifying listen interfaces via --listen"`
+	Listeners               []string      `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 8333, testnet: 18333)"`
+	MaxPeers                int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
+	MaxPeersPerIP           int           `long:"maxpeersperip" description:"Max number of inbound and outbound peers per IP"`
+	MinSyncPeerNetworkSpeed uint64        `long:"minsyncpeernetworkspeed" description:"Disconnect sync peers slower than this threshold in bytes/sec"`
+	DisableBanning          bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
+	BanDuration             time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
+	BanThreshold            uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
+	Whitelists              []string      `long:"whitelist" description:"Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)"`
+	RPCUser                 string        `short:"u" long:"rpcuser" description:"Username for RPC connections"`
+	RPCPass                 string        `short:"P" long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
+	RPCLimitUser            string        `long:"rpclimituser" description:"Username for limited RPC connections"`
+	RPCLimitPass            string        `long:"rpclimitpass" default-mask:"-" description:"Password for limited RPC connections"`
+	RPCListeners            []string      `long:"rpclisten" description:"Add an interface/port to listen for RPC connections (default port: 8334, testnet: 18334)"`
+	RPCCert                 string        `long:"rpccert" description:"File containing the certificate file"`
+	RPCKey                  string        `long:"rpckey" description:"File containing the certificate key"`
+	RPCMaxClients           int           `long:"rpcmaxclients" description:"Max number of RPC clients for standard connections"`
+	RPCMaxWebsockets        int           `long:"rpcmaxwebsockets" description:"Max number of RPC websocket connections"`
+	RPCMaxConcurrentReqs    int           `long:"rpcmaxconcurrentreqs" description:"Max number of concurrent RPC requests that may be processed concurrently"`
+	RPCQuirks               bool          `long:"rpcquirks" description:"Mirror some JSON-RPC quirks of Bitcoin Core -- NOTE: Discouraged unless interoperability issues need to be worked around"`
+	DisableRPC              bool          `long:"norpc" description:"Disable built-in RPC server -- NOTE: The RPC server is disabled by default if no rpcuser/rpcpass or rpclimituser/rpclimitpass is specified"`
+	DisableTLS              bool          `long:"notls" description:"Disable TLS for the RPC server -- NOTE: This is only allowed if the RPC server is bound to localhost"`
+	DisableDNSSeed          bool          `long:"nodnsseed" description:"Disable DNS seeding for peers"`
+	ExternalIPs             []string      `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
+	Proxy                   string        `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
+	ProxyUser               string        `long:"proxyuser" description:"Username for proxy server"`
+	ProxyPass               string        `long:"proxypass" default-mask:"-" description:"Password for proxy server"`
+	OnionProxy              string        `long:"onion" description:"Connect to tor hidden services via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
+	OnionProxyUser          string        `long:"onionuser" description:"Username for onion proxy server"`
+	OnionProxyPass          string        `long:"onionpass" default-mask:"-" description:"Password for onion proxy server"`
+	NoOnion                 bool          `long:"noonion" description:"Disable connecting to tor hidden services"`
+	TorIsolation            bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
+	TestNet3                bool          `long:"testnet" description:"Use the test network"`
+	TestNet1                bool          `long:"testnet1" description:"Use the testnet1 network"`
+	RegressionTest          bool          `long:"regtest" description:"Use the regression test network"`
+	SimNet                  bool          `long:"simnet" description:"Use the simulation test network"`
+	AddCheckpoints          []string      `long:"addcheckpoint" description:"Add a custom checkpoint.  Format: '<height>:<hash>'"`
+	DisableCheckpoints      bool          `long:"nocheckpoints" description:"Disable built-in checkpoints.  Don't do this unless you know what you're doing."`
+	DbType                  string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
+	Profile                 string        `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
+	CPUProfile              string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
+	DebugLevel              string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	Upnp                    bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
+	ExcessiveBlockSize      uint32        `long:"excessiveblocksize" description:"The maximum size block (in bytes) this node will accept. Cannot be less than 32000000."`
+	MinRelayTxFee           float64       `long:"minrelaytxfee" description:"The minimum transaction fee in BCH/kB to be considered a non-zero fee."`
+	FreeTxRelayLimit        float64       `long:"limitfreerelay" description:"Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute"`
+	NoRelayPriority         bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
+	TrickleInterval         time.Duration `long:"trickleinterval" description:"Minimum time between attempts to send new inventory to a connected peer"`
+	MaxOrphanTxs            int           `long:"maxorphantx" description:"Max number of orphan transactions to keep in memory"`
+	Generate                bool          `long:"generate" description:"Generate (mine) bitcoins using the CPU"`
+	MiningAddrs             []string      `long:"miningaddr" description:"Add the specified payment address to the list of addresses to use for generated blocks -- At least one address is required if the generate option is set"`
+	BlockMinSize            uint32        `long:"blockminsize" description:"Mininum block size in bytes to be used when creating a block"`
+	BlockMaxSize            uint32        `long:"blockmaxsize" description:"Maximum block size in bytes to be used when creating a block"`
+	BlockPrioritySize       uint32        `long:"blockprioritysize" description:"Size in bytes for high-priority/low-fee transactions when creating a block"`
+	UserAgentComments       []string      `long:"uacomment" description:"Comment to add to the user agent -- See BIP 14 for more information."`
+	NoPeerBloomFilters      bool          `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
+	NoCFilters              bool          `long:"nocfilters" description:"Disable committed filtering (CF) support"`
+	DropCfIndex             bool          `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
+	SigCacheMaxSize         uint          `long:"sigcachemaxsize" description:"The maximum number of entries in the signature verification cache"`
+	BlocksOnly              bool          `long:"blocksonly" description:"Do not accept transactions from remote peers."`
+	TxIndex                 bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
+	DropTxIndex             bool          `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
+	AddrIndex               bool          `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
+	DropAddrIndex           bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
+	RelayNonStd             bool          `long:"relaynonstd" description:"Relay non-standard transactions regardless of the default settings for the active network."`
+	RejectNonStd            bool          `long:"rejectnonstd" description:"Reject non-standard transactions regardless of the default settings for the active network."`
+	lookup                  func(string) ([]net.IP, error)
+	oniondial               func(string, string, time.Duration) (net.Conn, error)
+	dial                    func(string, string, time.Duration) (net.Conn, error)
+	addCheckpoints          []chaincfg.Checkpoint
+	miningAddrs             []bchutil.Address
+	minRelayTxFee           bchutil.Amount
+	whitelists              []*net.IPNet
 }
 
 // serviceOptions defines the configuration options for the daemon as a service on
@@ -410,32 +412,33 @@ func newConfigParser(cfg *config, so *serviceOptions, options flags.Options) *fl
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		ConfigFile:           defaultConfigFile,
-		DebugLevel:           defaultLogLevel,
-		MaxPeers:             defaultMaxPeers,
-		MaxPeersPerIP:        defaultMaxPeersPerIP,
-		BanDuration:          defaultBanDuration,
-		BanThreshold:         defaultBanThreshold,
-		RPCMaxClients:        defaultMaxRPCClients,
-		RPCMaxWebsockets:     defaultMaxRPCWebsockets,
-		RPCMaxConcurrentReqs: defaultMaxRPCConcurrentReqs,
-		DataDir:              defaultDataDir,
-		LogDir:               defaultLogDir,
-		DbType:               defaultDbType,
-		RPCKey:               defaultRPCKeyFile,
-		RPCCert:              defaultRPCCertFile,
-		ExcessiveBlockSize:   defaultExcessiveBlockSize,
-		MinRelayTxFee:        mempool.DefaultMinRelayTxFee.ToBCH(),
-		FreeTxRelayLimit:     defaultFreeTxRelayLimit,
-		TrickleInterval:      defaultTrickleInterval,
-		BlockMinSize:         defaultBlockMinSize,
-		BlockMaxSize:         defaultBlockMaxSize,
-		BlockPrioritySize:    mempool.DefaultBlockPrioritySize,
-		MaxOrphanTxs:         defaultMaxOrphanTransactions,
-		SigCacheMaxSize:      defaultSigCacheMaxSize,
-		Generate:             defaultGenerate,
-		TxIndex:              defaultTxIndex,
-		AddrIndex:            defaultAddrIndex,
+		ConfigFile:              defaultConfigFile,
+		DebugLevel:              defaultLogLevel,
+		MaxPeers:                defaultMaxPeers,
+		MaxPeersPerIP:           defaultMaxPeersPerIP,
+		MinSyncPeerNetworkSpeed: defaultMinSyncPeerNetworkSpeed,
+		BanDuration:             defaultBanDuration,
+		BanThreshold:            defaultBanThreshold,
+		RPCMaxClients:           defaultMaxRPCClients,
+		RPCMaxWebsockets:        defaultMaxRPCWebsockets,
+		RPCMaxConcurrentReqs:    defaultMaxRPCConcurrentReqs,
+		DataDir:                 defaultDataDir,
+		LogDir:                  defaultLogDir,
+		DbType:                  defaultDbType,
+		RPCKey:                  defaultRPCKeyFile,
+		RPCCert:                 defaultRPCCertFile,
+		ExcessiveBlockSize:      defaultExcessiveBlockSize,
+		MinRelayTxFee:           mempool.DefaultMinRelayTxFee.ToBCH(),
+		FreeTxRelayLimit:        defaultFreeTxRelayLimit,
+		TrickleInterval:         defaultTrickleInterval,
+		BlockMinSize:            defaultBlockMinSize,
+		BlockMaxSize:            defaultBlockMaxSize,
+		BlockPrioritySize:       mempool.DefaultBlockPrioritySize,
+		MaxOrphanTxs:            defaultMaxOrphanTransactions,
+		SigCacheMaxSize:         defaultSigCacheMaxSize,
+		Generate:                defaultGenerate,
+		TxIndex:                 defaultTxIndex,
+		AddrIndex:               defaultAddrIndex,
 	}
 
 	// Service options which are only added on Windows.

--- a/netsync/interface.go
+++ b/netsync/interface.go
@@ -38,4 +38,6 @@ type Config struct {
 	MaxPeers           int
 
 	FeeEstimator *mempool.FeeEstimator
+
+	MinSyncPeerNetworkSpeed uint64
 }

--- a/server.go
+++ b/server.go
@@ -2722,13 +2722,14 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	s.txMemPool = mempool.New(&txC)
 
 	s.syncManager, err = netsync.New(&netsync.Config{
-		PeerNotifier:       &s,
-		Chain:              s.chain,
-		TxMemPool:          s.txMemPool,
-		ChainParams:        s.chainParams,
-		DisableCheckpoints: cfg.DisableCheckpoints,
-		MaxPeers:           cfg.MaxPeers,
-		FeeEstimator:       s.feeEstimator,
+		PeerNotifier:            &s,
+		Chain:                   s.chain,
+		TxMemPool:               s.txMemPool,
+		ChainParams:             s.chainParams,
+		DisableCheckpoints:      cfg.DisableCheckpoints,
+		MaxPeers:                cfg.MaxPeers,
+		FeeEstimator:            s.feeEstimator,
+		MinSyncPeerNetworkSpeed: cfg.MinSyncPeerNetworkSpeed,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes: https://github.com/gcash/bchd/issues/98

This adds more logic to the sync manager so that slow sync peers are detected and disconnected.

Right now the rules are super simple, but it would be easy to adjust. We run the sync peer ticker every 30 seconds, if for 3 consecutive ticks the peer is below 50k/sec then they get disconnected.

The speed is configurable via the `minsyncpeernetworkspeed` command line flag, and the violations threshold can easily be changed via a constant in `manager.go`.