### PR TITLE
[Bug] Fix RPC reporting of protocol version

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -74,7 +74,7 @@ const (
 	gbtRegenerateSeconds = 60
 
 	// maxProtocolVersion is the max protocol version the server supports.
-	maxProtocolVersion = 70002
+	maxProtocolVersion = wire.FeeFilterVersion
 )
 
 var (


### PR DESCRIPTION
When you called `getinfo` it was reporting the wrong protocol version.