### PR TITLE
Fix rpcclient getnetworkhashps JSON marshall error 

### DIFF
--- a/rpcclient/mining.go
+++ b/rpcclient/mining.go
@@ -208,14 +208,14 @@ type FutureGetNetworkHashPS chan *response
 // Receive waits for the response promised by the future and returns the
 // estimated network hashes per second for the block heights provided by the
 // parameters.
-func (r FutureGetNetworkHashPS) Receive() (int64, error) {
+func (r FutureGetNetworkHashPS) Receive() (float64, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return -1, err
 	}
 
-	// Unmarshal result as an int64.
-	var result int64
+	// Unmarshal result as an float64.
+	var result float64
 	err = json.Unmarshal(res, &result)
 	if err != nil {
 		return 0, err
@@ -239,7 +239,7 @@ func (c *Client) GetNetworkHashPSAsync() FutureGetNetworkHashPS {
 //
 // See GetNetworkHashPS2 to override the number of blocks to use and
 // GetNetworkHashPS3 to override the height at which to calculate the estimate.
-func (c *Client) GetNetworkHashPS() (int64, error) {
+func (c *Client) GetNetworkHashPS() (float64, error) {
 	return c.GetNetworkHashPSAsync().Receive()
 }
 
@@ -260,7 +260,7 @@ func (c *Client) GetNetworkHashPS2Async(blocks int) FutureGetNetworkHashPS {
 //
 // See GetNetworkHashPS to use defaults and GetNetworkHashPS3 to override the
 // height at which to calculate the estimate.
-func (c *Client) GetNetworkHashPS2(blocks int) (int64, error) {
+func (c *Client) GetNetworkHashPS2(blocks int) (float64, error) {
 	return c.GetNetworkHashPS2Async(blocks).Receive()
 }
 
@@ -280,7 +280,7 @@ func (c *Client) GetNetworkHashPS3Async(blocks, height int) FutureGetNetworkHash
 // of blocks since the last difficulty change will be used.
 //
 // See GetNetworkHashPS and GetNetworkHashPS2 to use defaults.
-func (c *Client) GetNetworkHashPS3(blocks, height int) (int64, error) {
+func (c *Client) GetNetworkHashPS3(blocks, height int) (float64, error) {
 	return c.GetNetworkHashPS3Async(blocks, height).Receive()
 }
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -706,7 +706,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getmempoolinfo":        {(*btcjson.GetMempoolInfoResult)(nil)},
 	"getmininginfo":         {(*btcjson.GetMiningInfoResult)(nil)},
 	"getnettotals":          {(*btcjson.GetNetTotalsResult)(nil)},
-	"getnetworkhashps":      {(*int64)(nil)},
+	"getnetworkhashps":      {(*float64)(nil)},
 	"getpeerinfo":           {(*[]btcjson.GetPeerInfoResult)(nil)},
 	"getrawmempool":         {(*[]string)(nil), (*btcjson.GetRawMempoolVerboseResult)(nil)},
 	"getrawtransaction":     {(*string)(nil), (*btcjson.TxRawResult)(nil)},


### PR DESCRIPTION
With reference to issue https://github.com/gcash/bchd/issues/112 this PR fixes the rpcclient code to handle the float64 type.