### PR TITLE
Enhancement: Implemented output for block sync VerificationProgress on the RPC server and logger

### DIFF
--- a/blockchain/indexers/blocklogger.go
+++ b/blockchain/indexers/blocklogger.go
@@ -5,6 +5,7 @@
 package indexers
 
 import (
+	"math"
 	"sync"
 	"time"
 
@@ -40,7 +41,7 @@ func newBlockProgressLogger(progressMessage string, logger bchlog.Logger) *block
 // LogBlockHeight logs a new block height as an information message to show
 // progress to the user. In order to prevent spam, it limits logging to one
 // message every 10 seconds with duration and totals included.
-func (b *blockProgressLogger) LogBlockHeight(block *bchutil.Block) {
+func (b *blockProgressLogger) LogBlockHeight(block *bchutil.Block, bestHeight uint64) {
 	b.Lock()
 	defer b.Unlock()
 
@@ -66,9 +67,15 @@ func (b *blockProgressLogger) LogBlockHeight(block *bchutil.Block) {
 	if b.receivedLogTx == 1 {
 		txStr = "transaction"
 	}
-	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d, %s)",
+
+	progress := float64(0.0)
+	if bestHeight > 0 {
+		progress = math.Min(float64(block.Height())/float64(bestHeight), 1.0) * 100
+	}
+
+	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d of %d, progress %.2f%%, %s)",
 		b.progressAction, b.receivedLogBlocks, blockStr, tDuration, b.receivedLogTx,
-		txStr, block.Height(), block.MsgBlock().Header.Timestamp)
+		txStr, block.Height(), bestHeight, progress, block.MsgBlock().Header.Timestamp)
 
 	b.receivedLogBlocks = 0
 	b.receivedLogTx = 0

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -445,7 +445,7 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 		}
 
 		// Log indexing progress.
-		progressLogger.LogBlockHeight(block)
+		progressLogger.LogBlockHeight(block, uint64(bestHeight))
 
 		if interruptRequested(interrupt) {
 			return errInterruptRequested

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -124,6 +124,7 @@ type GetBlockChainInfoResult struct {
 	Difficulty           float64                             `json:"difficulty"`
 	MedianTime           int64                               `json:"mediantime"`
 	VerificationProgress float64                             `json:"verificationprogress,omitempty"`
+	SyncHeight           uint64                              `json:"syncheight,omitempty"`
 	Pruned               bool                                `json:"pruned"`
 	PruneHeight          int32                               `json:"pruneheight,omitempty"`
 	ChainWork            string                              `json:"chainwork,omitempty"`

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -388,6 +388,10 @@ func (sm *SyncManager) startSync() {
 
 // SyncHeight returns latest known block being synced to.
 func (sm *SyncManager) SyncHeight() uint64 {
+	if sm.syncPeer == nil {
+		return 0
+	}
+
 	return sm.syncPeerState.syncHeight
 }
 

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -161,6 +161,7 @@ type syncPeerState struct {
 	lastBlockTime     time.Time
 	violations        int
 	ticks             uint64
+	syncHeight        uint64
 }
 
 // validNetworkSpeed checks if the peer is slow and
@@ -378,10 +379,16 @@ func (sm *SyncManager) startSync() {
 			lastBlockTime:     time.Now(),
 			recvBytes:         bestPeer.BytesReceived(),
 			recvBytesLastTick: uint64(0),
+			syncHeight:        uint64(bestPeer.LastBlock()),
 		}
 	} else {
 		log.Warnf("No sync peer candidates available")
 	}
+}
+
+// SyncHeight returns latest known block being synced to.
+func (sm *SyncManager) SyncHeight() uint64 {
+	return sm.syncPeerState.syncHeight
 }
 
 // isSyncCandidate returns whether or not the peer is a candidate to consider
@@ -771,7 +778,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 
 		// When the block is not an orphan, log information about it and
 		// update the chain state.
-		sm.progressLogger.LogBlockHeight(bmsg.block)
+		sm.progressLogger.LogBlockHeight(bmsg.block, sm.SyncHeight())
 
 		// Update this peer's latest block height, for future
 		// potential sync node candidacy.

--- a/rpcadapters.go
+++ b/rpcadapters.go
@@ -285,3 +285,8 @@ func (b *rpcSyncMgr) SyncPeerID() int32 {
 func (b *rpcSyncMgr) LocateHeaders(locators []*chainhash.Hash, hashStop *chainhash.Hash) []wire.BlockHeader {
 	return b.server.chain.LocateHeaders(locators, hashStop)
 }
+
+// SyncHeight returns the block height of the best peer selected to sync from
+func (b *rpcSyncMgr) SyncHeight() uint64 {
+	return b.syncMgr.SyncHeight()
+}

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -181,6 +181,7 @@ var helpDescsEnUS = map[string]string{
 	"getblockchaininforesult-difficulty":            "The current chain difficulty",
 	"getblockchaininforesult-mediantime":            "The median time from the PoV of the best block in the chain",
 	"getblockchaininforesult-verificationprogress":  "An estimate for how much of the best chain we've verified",
+	"getblockchaininforesult-syncheight":            "The block height obtained from the best peer",
 	"getblockchaininforesult-pruned":                "A bool that indicates if the node is pruned or not",
 	"getblockchaininforesult-pruneheight":           "The lowest block retained in the current pruned chain",
 	"getblockchaininforesult-chainwork":             "The total cumulative work in the best chain",


### PR DESCRIPTION
The RPC server command `getblockchaininfo` supports field `VerificationProgress` but the logic to calculate and output this has not yet been implemented.  This PR adds support to the RPC server to do  this including a modification to the logger to output the progress of the block sync.

Given the RPC query `bchctl getblockchaininfo` the new output includes fields `verificationprogress` and `syncheight`.

<pre><code>
{
  "chain": "testnet3",
  "blocks": 949495,
  "headers": 949495,
  "bestblockhash": "0000000000b6aa443f707fd28ad62a0d127cf14bad7e1fee177b26704ed02f38",
  "difficulty": 1,
  "mediantime": 1475174633,
  <b>"verificationprogress": 0.7497141675010028,
  "syncheight": 1266476,</b>
  "pruned": false,
  "softforks": [
    {
      "id": "bip34",
      "version": 2,
      "reject": {
        "status": true
      }
    },
    {
      "id": "bip66",
      "version": 3,
      "reject": {
        "status": true
      }
    },
    {
      "id": "bip65",
      "version": 4,
      "reject": {
        "status": true
      }
    }
  ],
  "bip9_softforks": {
    "csv": {
      "status": "active",
      "bit": 0,
      "startTime": 1456790400,
      "timeout": 1493596800,
      "since": 0
    },
    "dummy": {
      "status": "failed",
      "bit": 28,
      "startTime": 1199145601,
      "timeout": 1230767999,
      "since": 0
    }
  }
}
</code></pre>

The logger output is modified to include the best `height` and sync `progress` as a percentage.

Original example
<pre><code>
2018-11-06 08:53:53.957 [INF] SYNC: Processed 2283 blocks in the last 10.01s (7961 transactions, height 742898, 2016-03-26 07:09:36 +0000 UTC)
</pre></code>

New modified example (see bold text for change)
<pre><code>
2018-11-06 09:38:49.017 [INF] SYNC: Processed 13 blocks in the last 14.44s (3198 transactions, <b>height 949499 of 1266476, progress 74.97%</b>, 2016-09-29 18:44:19 +0000 UTC)
</code></pre>