### PR TITLE
[Chore] Extend docker termination grace period to 5 minutes

### DIFF
--- a/kube/bchd-deployment.yml
+++ b/kube/bchd-deployment.yml
@@ -38,6 +38,7 @@ spec:
           requests:
             memory: "3Gi"
       restartPolicy: Always
+      terminationGracePeriodSeconds: 300
       volumes:
         - name: bchd-data
           gcePersistentDisk:


### PR DESCRIPTION
Wanted this in before the utxo cache changes land. This extends the termination grace period to 5 minutes. This should avoid nasty shutdown issues.