### PR TITLE
[Fix] Set ExcessiveBlockSize for addblock

### DIFF
--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -335,6 +335,9 @@ func newBlockImporter(db database.DB, r io.ReadSeeker) (*blockImporter, error) {
 		ChainParams:  activeNetParams,
 		TimeSource:   blockchain.NewMedianTime(),
 		IndexManager: indexManager,
+		// No nice way to get the main configuration here.
+		// For now just accept up to the default.
+		ExcessiveBlockSize: 32000000,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There isn't a good way to get to the ExcessiveBlockSize parameter from the main binary. For now I just set it to the default.

Fixes https://github.com/gcash/bchd/issues/116