### PR TITLE
bug fixes to block sync progress reporting

### DIFF
--- a/blockchain/indexers/blocklogger.go
+++ b/blockchain/indexers/blocklogger.go
@@ -5,6 +5,7 @@
 package indexers
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -69,13 +70,25 @@ func (b *blockProgressLogger) LogBlockHeight(block *bchutil.Block, bestHeight ui
 	}
 
 	progress := float64(0.0)
+
 	if bestHeight > 0 {
 		progress = math.Min(float64(block.Height())/float64(bestHeight), 1.0) * 100
 	}
 
-	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d of %d, progress %.2f%%, %s)",
+	var heightStr string
+
+	if uint64(block.Height()) >= bestHeight {
+		// sync is up to date so shorten the height output
+		heightStr = fmt.Sprintf("%d (%.2f%%)", block.Height(), progress)
+	} else {
+		// sync is partial and in progress
+		heightStr = fmt.Sprintf("%d/%d (%.2f%%)", block.Height(),
+			bestHeight, progress)
+	}
+
+	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %s, %s)",
 		b.progressAction, b.receivedLogBlocks, blockStr, tDuration, b.receivedLogTx,
-		txStr, block.Height(), bestHeight, progress, block.MsgBlock().Header.Timestamp)
+		txStr, heightStr, block.MsgBlock().Header.Timestamp)
 
 	b.receivedLogBlocks = 0
 	b.receivedLogTx = 0

--- a/netsync/blocklogger.go
+++ b/netsync/blocklogger.go
@@ -5,6 +5,7 @@
 package netsync
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -69,13 +70,25 @@ func (b *blockProgressLogger) LogBlockHeight(block *bchutil.Block, bestHeight ui
 	}
 
 	progress := float64(0.0)
+
 	if bestHeight > 0 {
 		progress = math.Min(float64(block.Height())/float64(bestHeight), 1.0) * 100
 	}
 
-	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d of %d, progress %.2f%%, %s)",
+	var heightStr string
+
+	if uint64(block.Height()) >= bestHeight {
+		// sync is up to date so shorten the height output
+		heightStr = fmt.Sprintf("%d (%.2f%%)", block.Height(), progress)
+	} else {
+		// sync is partial and in progress
+		heightStr = fmt.Sprintf("%d/%d (%.2f%%)", block.Height(),
+			bestHeight, progress)
+	}
+
+	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %s, %s)",
 		b.progressAction, b.receivedLogBlocks, blockStr, tDuration, b.receivedLogTx,
-		txStr, block.Height(), bestHeight, progress, block.MsgBlock().Header.Timestamp)
+		txStr, heightStr, block.MsgBlock().Header.Timestamp)
 
 	b.receivedLogBlocks = 0
 	b.receivedLogTx = 0

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -161,7 +161,6 @@ type syncPeerState struct {
 	lastBlockTime     time.Time
 	violations        int
 	ticks             uint64
-	syncHeight        uint64
 }
 
 // validNetworkSpeed checks if the peer is slow and
@@ -379,7 +378,6 @@ func (sm *SyncManager) startSync() {
 			lastBlockTime:     time.Now(),
 			recvBytes:         bestPeer.BytesReceived(),
 			recvBytesLastTick: uint64(0),
-			syncHeight:        uint64(bestPeer.LastBlock()),
 		}
 	} else {
 		log.Warnf("No sync peer candidates available")
@@ -392,7 +390,7 @@ func (sm *SyncManager) SyncHeight() uint64 {
 		return 0
 	}
 
-	return sm.syncPeerState.syncHeight
+	return uint64(sm.topBlock())
 }
 
 // isSyncCandidate returns whether or not the peer is a candidate to consider
@@ -473,15 +471,9 @@ func (sm *SyncManager) handleCheckSyncPeer() {
 
 	// Don't update sync peers if you have all the available
 	// blocks.
-	var topBlock int32
-	if sm.syncPeer.LastBlock() > sm.syncPeer.StartingHeight() {
-		topBlock = sm.syncPeer.LastBlock()
-	} else {
-		topBlock = sm.syncPeer.StartingHeight()
-	}
 
 	best := sm.chain.BestSnapshot()
-	if topBlock == best.Height {
+	if sm.topBlock() == best.Height {
 		// Update the time and violations to prevent disconnects.
 		sm.syncPeerState.lastBlockTime = time.Now()
 		sm.syncPeerState.violations = 0
@@ -495,6 +487,16 @@ func (sm *SyncManager) handleCheckSyncPeer() {
 
 	sm.clearRequestedState(state)
 	sm.updateSyncPeer(state)
+}
+
+// topBlock returns the best chains top block height
+func (sm *SyncManager) topBlock() int32 {
+
+	if sm.syncPeer.LastBlock() > sm.syncPeer.StartingHeight() {
+		return sm.syncPeer.LastBlock()
+	}
+
+	return sm.syncPeer.StartingHeight()
 }
 
 // handleDonePeerMsg deals with peers that have signalled they are done.  It


### PR DESCRIPTION
Per discussion in https://github.com/gcash/bchd/issues/115 this PR fixes the following;

1. Fix the stale variable usage
2. Shorten the progress output to format of `height 1260193/1266701 (99.49%)`
3. Adjust the code to handle the data race so an up to date chain reports `height 1266701 (100.00%)`

Sample output whilst syncing
```
2018-11-07 22:50:19.384 [INF] SYNC: Processed 794 blocks in the last 10s (6045 transactions, height 141466/1233077 (11.47%), 2013-11-15 10:52:42 +0000 UTC)
2018-11-07 22:50:29.390 [INF] SYNC: Processed 1426 blocks in the last 10s (6385 transactions, height 142892/1233077 (11.59%), 2013-11-16 00:54:58 +0000 UTC)
2018-11-07 22:50:39.392 [INF] SYNC: Processed 855 blocks in the last 10s (6598 transactions, height 143747/1233077 (11.66%), 2013-11-16 20:39:05 +0000 UTC)
2018-11-07 22:50:49.398 [INF] SYNC: Processed 1318 blocks in the last 10s (4911 transactions, height 145065/1233077 (11.76%), 2013-11-18 23:28:58 +0000 UTC)
```

Sample output on up to date synced node
```
2018-11-07 23:06:43.112 [INF] SYNC: Processed 1 block in the last 4m1.82s (7 transactions, height 1266742 (100.00%), 2018-11-07 23:07:01 +0000 UTC)
2018-11-07 23:16:10.344 [INF] SYNC: Processed 1 block in the last 9m27.23s (7 transactions, height 1266743 (100.00%), 2018-11-07 23:15:49 +0000 UTC)
```
