### PR TITLE
[FIX] Make node errors visible in integration tests and always clean up

### DIFF
--- a/bchd.go
+++ b/bchd.go
@@ -329,6 +329,7 @@ func main() {
 
 	// Work around defer not working after os.Exit()
 	if err := bchdMain(nil); err != nil {
+		fmt.Fprintf(os.Stderr, "error running node: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -133,10 +133,10 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	if err != nil {
 		t.Fatalf("unable to create primary harness: %v", err)
 	}
+	defer r.TearDown()
 	if err := r.SetUp(false, 0); err != nil {
 		t.Fatalf("unable to setup test chain: %v", err)
 	}
-	defer r.TearDown()
 
 	// *** ThresholdDefined ***
 	//
@@ -323,10 +323,10 @@ func TestBIP0009Mining(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create primary harness: %v", err)
 	}
+	defer r.TearDown()
 	if err := r.SetUp(true, 0); err != nil {
 		t.Fatalf("unable to setup test chain: %v", err)
 	}
-	defer r.TearDown()
 
 	// Assert the chain only consists of the gensis block.
 	assertChainHeight(r, t, 0)

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -113,10 +113,10 @@ func TestBIP0113Activation(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to create primary harness: ", err)
 	}
+	defer r.TearDown()
 	if err := r.SetUp(true, 1); err != nil {
 		t.Fatalf("unable to setup test chain: %v", err)
 	}
-	defer r.TearDown()
 
 	// Create a fresh output for usage within the test below.
 	const outputValue = bchutil.SatoshiPerBitcoin
@@ -425,10 +425,10 @@ func TestBIP0068AndBIP0112Activation(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to create primary harness: ", err)
 	}
+	defer r.TearDown()
 	if err := r.SetUp(true, 1); err != nil {
 		t.Fatalf("unable to setup test chain: %v", err)
 	}
-	defer r.TearDown()
 
 	assertSoftForkStatus(r, t, csvKey, blockchain.ThresholdStarted)
 

--- a/integration/rpctest/bchd.go
+++ b/integration/rpctest/bchd.go
@@ -7,6 +7,7 @@ package rpctest
 import (
 	"fmt"
 	"go/build"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -62,6 +63,7 @@ func bchdExecutablePath() (string, error) {
 		outputPath += ".exe"
 	}
 	cmd := exec.Command("go", "build", "-o", outputPath, bchdPkg.ImportPath)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	err = cmd.Run()
 	if err != nil {
 		return "", fmt.Errorf("Failed to build bchd: %v", err)

--- a/integration/rpctest/node.go
+++ b/integration/rpctest/node.go
@@ -137,7 +137,10 @@ func (n *nodeConfig) arguments() []string {
 
 // command returns the exec.Cmd which will be used to start the btcd process.
 func (n *nodeConfig) command() *exec.Cmd {
-	return exec.Command(n.exe, n.arguments()...)
+	c := exec.Command(n.exe, n.arguments()...)
+	// allow visibility to node (mis)behavior
+	c.Stdout, c.Stderr = os.Stdout, os.Stderr
+	return c
 }
 
 // rpcConnConfig returns the rpc connection config that can be used to connect

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -272,21 +272,26 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 //
 // This function MUST be called with the harness state mutex held (for writes).
 func (h *Harness) tearDown() error {
+	var returnErr error
+
+	// try to do all shutdown steps and return the last error, if any
 	if h.Node != nil {
 		h.Node.Shutdown()
 	}
 
 	if err := h.node.shutdown(); err != nil {
-		return err
+		fmt.Println("error shutting down node:", err)
+		returnErr = err
 	}
 
 	if err := os.RemoveAll(h.testNodeDir); err != nil {
-		return err
+		fmt.Println("error removing test node artifacts:", err)
+		returnErr = err
 	}
 
 	delete(testInstances, h.testNodeDir)
 
-	return nil
+	return returnErr
 }
 
 // TearDown stops the running rpc test instance. All created processes are

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -109,10 +109,10 @@ func testConnectNode(r *Harness, t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer harness.TearDown()
 	if err := harness.SetUp(false, 0); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
-	defer harness.TearDown()
 
 	// Establish a p2p connection from our new local harness to the main
 	// harness.
@@ -185,10 +185,10 @@ func testJoinMempools(r *Harness, t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer harness.TearDown()
 	if err := harness.SetUp(false, 0); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
-	defer harness.TearDown()
 
 	nodeSlice := []*Harness{r, harness}
 
@@ -288,10 +288,10 @@ func testJoinBlocks(r *Harness, t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer harness.TearDown()
 	if err := harness.SetUp(false, 0); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
-	defer harness.TearDown()
 
 	nodeSlice := []*Harness{r, harness}
 	blocksSynced := make(chan struct{})
@@ -476,10 +476,10 @@ func testMemWalletReorg(r *Harness, t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer harness.TearDown()
 	if err := harness.SetUp(true, 5); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
-	defer harness.TearDown()
 
 	// The internal wallet of this harness should now have 250 BCH.
 	expectedBalance := bchutil.Amount(250 * bchutil.SatoshiPerBitcoin)
@@ -568,39 +568,46 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	var err error
+	var (
+		err      error
+		exitCode int
+	)
+	// Whatever happens, clean up active harnesses and exit with the last exit code.
+	// Note that Exit at the end of the function would ignore any defers.
+	defer func() {
+		// Clean up any active harnesses that are still currently running.This
+		// includes removing all temporary directories, and shutting down any
+		// created processes.
+		if err := TearDownAll(); err != nil {
+			// Don't set exitCode for a teardown error. Just make it visible.
+			fmt.Println("unable to tear down chain: ", err)
+		}
+		os.Exit(exitCode)
+	}()
+
 	mainHarness, err = New(&chaincfg.SimNetParams, nil, nil)
 	if err != nil {
 		fmt.Println("unable to create main harness: ", err)
-		os.Exit(1)
+		exitCode = 1
+		return
 	}
+	defer func() {
+		if err := mainHarness.TearDown(); err != nil {
+			// Don't set exitCode for a teardown error. Just make it visible.
+			fmt.Println("error tearing down main harness:", err)
+		}
+	}()
 
 	// Initialize the main mining node with a chain of length 125,
 	// providing 25 mature coinbases to allow spending from for testing
 	// purposes.
 	if err = mainHarness.SetUp(true, numMatureOutputs); err != nil {
 		fmt.Println("unable to setup test chain: ", err)
-
-		// Even though the harness was not fully setup, it still needs
-		// to be torn down to ensure all resources such as temp
-		// directories are cleaned up.  The error is intentionally
-		// ignored since this is already an error path and nothing else
-		// could be done about it anyways.
-		_ = mainHarness.TearDown()
-		os.Exit(1)
+		exitCode = 1
+		return
 	}
 
-	exitCode := m.Run()
-
-	// Clean up any active harnesses that are still currently running.
-	if len(ActiveHarnesses()) > 0 {
-		if err := TearDownAll(); err != nil {
-			fmt.Println("unable to tear down chain: ", err)
-			os.Exit(1)
-		}
-	}
-
-	os.Exit(exitCode)
+	exitCode = m.Run()
 }
 
 func TestHarness(t *testing.T) {


### PR DESCRIPTION
Fixes #122

The root problem of #122 is basically that low test coverage allows the node to fail unexpectedly in the integration test. This PR should make it easier to find those cases until coverage is higher also keep `/tmp` clean for what that is worth.

This PR still leaves the test binary at `bchd/rpctest/bchd` but it's always the same place so /shrug.
