### PR TITLE
[FIX] make dependent wire limits actually dependent

### DIFF
--- a/bchd.go
+++ b/bchd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gcash/bchd/database"
 	"github.com/gcash/bchd/limits"
 	"github.com/gcash/bchd/version"
+	"github.com/gcash/bchd/wire"
 )
 
 const (
@@ -54,6 +55,9 @@ func bchdMain(serverChan chan<- *server) error {
 			logRotator.Close()
 		}
 	}()
+
+	// Do required one-time initialization on wire
+	wire.SetLimits(cfg.ExcessiveBlockSize)
 
 	// Get a channel that will be closed when a shutdown signal has been
 	// triggered either from an OS signal such as SIGINT (Ctrl+C) or from

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1856,10 +1856,6 @@ func New(config *Config) (*BlockChain, error) {
 		return nil, AssertError("blockchain.New excessive block size set lower than LegacyBlockSize")
 	}
 
-	// Set the MaxMessagePayload size in the wire package based on the excessive block configuration
-	// The default is set to 64MB but should go higher if the user enters a larger ExcessiveBlockSize
-	wire.MaxMessagePayload = ((config.ExcessiveBlockSize / 1000000) * 1024 * 1024) * 2
-
 	// Generate a checkpoint by height map from the provided checkpoints
 	// and assert the provided checkpoints are sorted by height as required.
 	var checkpointsByHeight map[int32]*chaincfg.Checkpoint

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -15,7 +15,8 @@ import (
 	"github.com/gcash/bchutil"
 )
 
-const fixedExcessiveBlockSize uint32 = 64000000
+// fixedExcessiveBlockSize should not be the default -we want to ensure it will work in all cases
+const fixedExcessiveBlockSize uint32 = 42111000
 
 func init() {
 	wire.SetLimits(fixedExcessiveBlockSize)

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -15,6 +15,12 @@ import (
 	"github.com/gcash/bchutil"
 )
 
+const fixedExcessiveBlockSize uint32 = 64000000
+
+func init() {
+	wire.SetLimits(fixedExcessiveBlockSize)
+}
+
 // TestHaveBlock tests the HaveBlock API to ensure proper functionality.
 func TestHaveBlock(t *testing.T) {
 	// Load up blocks such that there is a side chain.

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -72,10 +72,10 @@ func (bi *blockImporter) readBlock() ([]byte, error) {
 	if err := binary.Read(bi.r, binary.LittleEndian, &blockLen); err != nil {
 		return nil, err
 	}
-	if blockLen > wire.MaxBlockPayload {
+	if blockLen > wire.MaxBlockPayload() {
 		return nil, fmt.Errorf("block payload of %d bytes is larger "+
 			"than the max allowed %d bytes", blockLen,
-			wire.MaxBlockPayload)
+			wire.MaxBlockPayload())
 	}
 
 	serializedBlock := make([]byte, blockLen)

--- a/config.go
+++ b/config.go
@@ -56,7 +56,6 @@ const (
 	defaultBlockMinSize            = 0
 	defaultBlockMaxSize            = 750000
 	blockMaxSizeMin                = 1000
-	blockMaxSizeMax                = defaultExcessiveBlockSize - 1000
 	defaultGenerate                = false
 	defaultMaxOrphanTransactions   = 100
 	defaultMaxOrphanTxSize         = 100000
@@ -789,19 +788,6 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// Limit the max block size to a sane value.
-	if cfg.BlockMaxSize < blockMaxSizeMin || cfg.BlockMaxSize >
-		blockMaxSizeMax {
-
-		str := "%s: The blockmaxsize option must be in between %d " +
-			"and %d -- parsed [%d]"
-		err := fmt.Errorf(str, funcName, blockMaxSizeMin,
-			blockMaxSizeMax, cfg.BlockMaxSize)
-		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintln(os.Stderr, usageMessage)
-		return nil, nil, err
-	}
-
 	// Limit the max orphan count to a sane vlue.
 	if cfg.MaxOrphanTxs < 0 {
 		str := "%s: The maxorphantx option may not be less than 0 " +
@@ -815,6 +801,19 @@ func loadConfig() (*config, []string, error) {
 	// Excessive blocksize cannot be set less than the default but it can be higher.
 	cfg.ExcessiveBlockSize = maxUint32(cfg.ExcessiveBlockSize, defaultExcessiveBlockSize)
 
+	// Limit the max block size to a sane value.
+	blockMaxSizeMax := cfg.ExcessiveBlockSize - 1000
+	if cfg.BlockMaxSize < blockMaxSizeMin || cfg.BlockMaxSize >
+		blockMaxSizeMax {
+
+		str := "%s: The blockmaxsize option must be in between %d " +
+			"and %d -- parsed [%d]"
+		err := fmt.Errorf(str, funcName, blockMaxSizeMin,
+			blockMaxSizeMax, cfg.BlockMaxSize)
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, usageMessage)
+		return nil, nil, err
+	}
 	// Limit the block priority and minimum block sizes to max block size.
 	cfg.BlockPrioritySize = minUint32(cfg.BlockPrioritySize, cfg.BlockMaxSize)
 	cfg.BlockMinSize = minUint32(cfg.BlockMinSize, cfg.BlockMaxSize)

--- a/database/cmd/dbtool/insecureimport.go
+++ b/database/cmd/dbtool/insecureimport.go
@@ -86,10 +86,10 @@ func (bi *blockImporter) readBlock() ([]byte, error) {
 	if err := binary.Read(bi.r, binary.LittleEndian, &blockLen); err != nil {
 		return nil, err
 	}
-	if blockLen > wire.MaxBlockPayload {
+	if blockLen > wire.MaxBlockPayload() {
 		return nil, fmt.Errorf("block payload of %d bytes is larger "+
 			"than the max allowed %d bytes", blockLen,
-			wire.MaxBlockPayload)
+			wire.MaxBlockPayload())
 	}
 
 	serializedBlock := make([]byte, blockLen)

--- a/database/driver_test.go
+++ b/database/driver_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/gcash/bchd/wire"
 )
 
-const fixedExcessiveBlockSize uint32 = 64000000
+// fixedExcessiveBlockSize should not be the default -we want to ensure it will work in all cases
+const fixedExcessiveBlockSize uint32 = 42111000
 
 func init() {
 	wire.SetLimits(fixedExcessiveBlockSize)

--- a/database/driver_test.go
+++ b/database/driver_test.go
@@ -10,7 +10,14 @@ import (
 
 	"github.com/gcash/bchd/database"
 	_ "github.com/gcash/bchd/database/ffldb"
+	"github.com/gcash/bchd/wire"
 )
+
+const fixedExcessiveBlockSize uint32 = 64000000
+
+func init() {
+	wire.SetLimits(fixedExcessiveBlockSize)
+}
 
 var (
 	// ignoreDbTypes are types which should be ignored when running tests

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -25,7 +25,8 @@ import (
 	"github.com/gcash/bchutil"
 )
 
-const fixedExcessiveBlockSize uint32 = 64000000
+// fixedExcessiveBlockSize should not be the default -we want to ensure it will work in all cases
+const fixedExcessiveBlockSize uint32 = 42111000
 
 func init() {
 	wire.SetLimits(fixedExcessiveBlockSize)

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -25,6 +25,12 @@ import (
 	"github.com/gcash/bchutil"
 )
 
+const fixedExcessiveBlockSize uint32 = 64000000
+
+func init() {
+	wire.SetLimits(fixedExcessiveBlockSize)
+}
+
 var (
 	// blockDataNet is the expected network in the test block data.
 	// The serialized test data uses the Bitcoin Core network magic.

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -24,6 +24,12 @@ import (
 	"github.com/gcash/bchutil"
 )
 
+const fixedExcessiveBlockSize uint32 = 64000000
+
+func init() {
+	wire.SetLimits(fixedExcessiveBlockSize)
+}
+
 const (
 	csvKey = "csv"
 )

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -24,7 +24,8 @@ import (
 	"github.com/gcash/bchutil"
 )
 
-const fixedExcessiveBlockSize uint32 = 64000000
+// fixedExcessiveBlockSize should not be the default -we want to ensure it will work in all cases
+const fixedExcessiveBlockSize uint32 = 42111000
 
 func init() {
 	wire.SetLimits(fixedExcessiveBlockSize)

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -20,7 +20,8 @@ import (
 	"github.com/gcash/bchutil"
 )
 
-const fixedExcessiveBlockSize uint32 = 64000000
+// fixedExcessiveBlockSize should not be the default -we want to ensure it will work in all cases
+const fixedExcessiveBlockSize uint32 = 42111000
 
 func init() {
 	wire.SetLimits(fixedExcessiveBlockSize)

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -20,6 +20,12 @@ import (
 	"github.com/gcash/bchutil"
 )
 
+const fixedExcessiveBlockSize uint32 = 64000000
+
+func init() {
+	wire.SetLimits(fixedExcessiveBlockSize)
+}
+
 func testSendOutputs(r *Harness, t *testing.T) {
 	genSpend := func(amt bchutil.Amount) *chainhash.Hash {
 		// Grab a fresh address from the wallet.

--- a/netsync/common_test.go
+++ b/netsync/common_test.go
@@ -20,7 +20,8 @@ import (
 	"github.com/gcash/bchutil"
 )
 
-const fixedExcessiveBlockSize uint32 = 64000000
+// fixedExcessiveBlockSize should not be the default -we want to ensure it will work in all cases
+const fixedExcessiveBlockSize uint32 = 42111000
 
 func init() {
 	wire.SetLimits(fixedExcessiveBlockSize)

--- a/netsync/common_test.go
+++ b/netsync/common_test.go
@@ -20,6 +20,12 @@ import (
 	"github.com/gcash/bchutil"
 )
 
+const fixedExcessiveBlockSize uint32 = 64000000
+
+func init() {
+	wire.SetLimits(fixedExcessiveBlockSize)
+}
+
 /* This file contains mock structs and helper functions that are shared by tests
  * in the netsync_test package.
  */

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -20,6 +20,12 @@ import (
 	"github.com/gcash/bchd/wire"
 )
 
+const fixedExcessiveBlockSize uint32 = 64000000
+
+func init() {
+	wire.SetLimits(fixedExcessiveBlockSize)
+}
+
 // conn mocks a network connection by implementing the net.Conn interface.  It
 // is used to test peer connection without actually opening a network
 // connection.

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -20,7 +20,8 @@ import (
 	"github.com/gcash/bchd/wire"
 )
 
-const fixedExcessiveBlockSize uint32 = 64000000
+// fixedExcessiveBlockSize should not be the default -we want to ensure it will work in all cases
+const fixedExcessiveBlockSize uint32 = 42111000
 
 func init() {
 	wire.SetLimits(fixedExcessiveBlockSize)

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -20,7 +20,8 @@ import (
 	"github.com/gcash/bchutil"
 )
 
-const fixedExcessiveBlockSize uint32 = 64000000
+// fixedExcessiveBlockSize should not be the default -we want to ensure it will work in all cases
+const fixedExcessiveBlockSize uint32 = 42111000
 
 func init() {
 	wire.SetLimits(fixedExcessiveBlockSize)

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -20,6 +20,12 @@ import (
 	"github.com/gcash/bchutil"
 )
 
+const fixedExcessiveBlockSize uint32 = 64000000
+
+func init() {
+	wire.SetLimits(fixedExcessiveBlockSize)
+}
+
 // scriptTestName returns a descriptive test name for the given reference script
 // test data.
 func scriptTestName(test []interface{}) (string, error) {

--- a/wire/common.go
+++ b/wire/common.go
@@ -601,9 +601,9 @@ func ReadVarString(r io.Reader, pver uint32) (string, error) {
 	// Prevent variable length strings that are larger than the maximum
 	// message size.  It would be possible to cause memory exhaustion and
 	// panics without a sane upper bound on this count.
-	if count > uint64(MaxMessagePayload) {
+	if count > uint64(maxMessagePayload()) {
 		str := fmt.Sprintf("variable length string is too long "+
-			"[count %d, max %d]", count, MaxMessagePayload)
+			"[count %d, max %d]", count, maxMessagePayload())
 		return "", messageError("ReadVarString", str)
 	}
 

--- a/wire/common_test.go
+++ b/wire/common_test.go
@@ -41,7 +41,8 @@ type fakeRandReader struct {
 	err error
 }
 
-const fixedExcessiveBlockSize uint32 = 64000000
+// fixedExcessiveBlockSize should not be the default -we want to ensure it will work in all cases
+const fixedExcessiveBlockSize uint32 = 42111000
 
 func init() {
 	// Wire package requires initialization

--- a/wire/common_test.go
+++ b/wire/common_test.go
@@ -41,6 +41,13 @@ type fakeRandReader struct {
 	err error
 }
 
+const fixedExcessiveBlockSize uint32 = 64000000
+
+func init() {
+	// Wire package requires initialization
+	SetLimits(fixedExcessiveBlockSize)
+}
+
 // Read returns the fake reader error and the lesser of the fake reader value
 // and the length of p.
 func (r *fakeRandReader) Read(p []byte) (int, error) {
@@ -614,7 +621,7 @@ func TestVarBytesWire(t *testing.T) {
 
 		// Decode from wire format.
 		rbuf := bytes.NewReader(test.buf)
-		val, err := ReadVarBytes(rbuf, test.pver, MaxMessagePayload,
+		val, err := ReadVarBytes(rbuf, test.pver, maxMessagePayload(),
 			"test payload")
 		if err != nil {
 			t.Errorf("ReadVarBytes #%d error %v", i, err)
@@ -666,7 +673,7 @@ func TestVarBytesWireErrors(t *testing.T) {
 
 		// Decode from wire format.
 		r := newFixedReader(test.max, test.buf)
-		_, err = ReadVarBytes(r, test.pver, MaxMessagePayload,
+		_, err = ReadVarBytes(r, test.pver, maxMessagePayload(),
 			"test payload")
 		if err != test.readErr {
 			t.Errorf("ReadVarBytes #%d wrong error got: %v, want: %v",
@@ -698,7 +705,7 @@ func TestVarBytesOverflowErrors(t *testing.T) {
 	for i, test := range tests {
 		// Decode from wire format.
 		rbuf := bytes.NewReader(test.buf)
-		_, err := ReadVarBytes(rbuf, test.pver, MaxMessagePayload,
+		_, err := ReadVarBytes(rbuf, test.pver, maxMessagePayload(),
 			"test payload")
 		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
 			t.Errorf("ReadVarBytes #%d wrong error got: %v, "+

--- a/wire/message.go
+++ b/wire/message.go
@@ -23,26 +23,18 @@ const MessageHeaderSize = 24
 const CommandSize = 12
 
 // ebs is the excessive block size, used to determine reasonable maximum message sizes.
-var ebs uint32
+// 32MB is the current default value
+var ebs uint32 = 32000000
 
-// SetLimits initializes various message limits which change depending on the maximum
-// block size we will deal with.
+// SetLimits adjusts various message limits based on max block size configuration.
 func SetLimits(excessiveBlockSize uint32) {
 	ebs = excessiveBlockSize
 }
 
-func getEBS() uint32 {
-	if ebs == 0 {
-		panic("message size limits have not been initialized")
-	}
-	return ebs
-}
-
 // MaxMessagePayload returns is the maximum bytes a message can be regardless of other
-// individual limits imposed by messages themselves. It will panic if the value
-// has not been initialized.
+// individual limits imposed by messages themselves.
 func maxMessagePayload() uint32 {
-	return ((getEBS() / 1000000) * 1024 * 1024) * 2
+	return ((ebs / 1000000) * 1024 * 1024) * 2
 }
 
 // Commands used in bitcoin message headers which describe the type of message.

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -203,7 +203,7 @@ func TestReadMessageWireErrors(t *testing.T) {
 
 	// Wire encoded bytes for a message that exceeds max overall message
 	// length.
-	mpl := uint32(MaxMessagePayload)
+	mpl := uint32(maxMessagePayload())
 	exceedMaxPayloadBytes := makeHeader(bchnet, "getaddr", mpl+1, 0)
 
 	// Wire encoded bytes for a command which is invalid utf-8.
@@ -392,7 +392,7 @@ func TestWriteMessageWireErrors(t *testing.T) {
 	encodeErrMsg := &fakeMessage{forceEncodeErr: true}
 
 	// Fake message that has payload which exceeds max overall message size.
-	exceedOverallPayload := make([]byte, MaxMessagePayload+1)
+	exceedOverallPayload := make([]byte, maxMessagePayload()+1)
 	exceedOverallPayloadErrMsg := &fakeMessage{payload: exceedOverallPayload}
 
 	// Fake message that has payload which exceeds max allowed per message.

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -22,12 +22,16 @@ const defaultTransactionAlloc = 2048
 // MaxBlocksPerMsg is the maximum number of blocks allowed per message.
 const MaxBlocksPerMsg = 500
 
-// MaxBlockPayload is the maximum bytes a block message can be in bytes.
-const MaxBlockPayload = 32000000
+// MaxBlockPayload returns the maximum bytes a block message can be in bytes.
+func MaxBlockPayload() uint32 {
+	return ebs
+}
 
-// maxTxPerBlock is the maximum number of transactions that could
+// maxTxPerBlock returns the maximum number of transactions that could
 // possibly fit into a block.
-const maxTxPerBlock = (MaxBlockPayload / minTxPayload) + 1
+func maxTxPerBlock() uint32 {
+	return (MaxBlockPayload() / minTxPayload) + 1
+}
 
 // TxLoc holds locator data for the offset and length of where a transaction is
 // located within a MsgBlock data buffer.
@@ -74,9 +78,9 @@ func (msg *MsgBlock) BchDecode(r io.Reader, pver uint32, enc MessageEncoding) er
 	// Prevent more transactions than could possibly fit into a block.
 	// It would be possible to cause memory exhaustion and panics without
 	// a sane upper bound on this count.
-	if txCount > maxTxPerBlock {
+	if txCount > uint64(maxTxPerBlock()) {
 		str := fmt.Sprintf("too many transactions to fit into a block "+
-			"[count %d, max %d]", txCount, maxTxPerBlock)
+			"[count %d, max %d]", txCount, maxTxPerBlock())
 		return messageError("MsgBlock.BchDecode", str)
 	}
 
@@ -132,9 +136,9 @@ func (msg *MsgBlock) DeserializeTxLoc(r *bytes.Buffer) ([]TxLoc, error) {
 	// Prevent more transactions than could possibly fit into a block.
 	// It would be possible to cause memory exhaustion and panics without
 	// a sane upper bound on this count.
-	if txCount > maxTxPerBlock {
+	if txCount > uint64(maxTxPerBlock()) {
 		str := fmt.Sprintf("too many transactions to fit into a block "+
-			"[count %d, max %d]", txCount, maxTxPerBlock)
+			"[count %d, max %d]", txCount, maxTxPerBlock())
 		return nil, messageError("MsgBlock.DeserializeTxLoc", str)
 	}
 
@@ -223,7 +227,7 @@ func (msg *MsgBlock) MaxPayloadLength(pver uint32) uint32 {
 	// Block header at 80 bytes + transaction count + max transactions
 	// which can vary up to the MaxBlockPayload (including the block header
 	// and transaction count).
-	return MaxBlockPayload
+	return MaxBlockPayload()
 }
 
 // BlockHash computes the block identifier hash for this block.

--- a/wire/msgblock_test.go
+++ b/wire/msgblock_test.go
@@ -36,7 +36,7 @@ func TestBlock(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
-	wantPayload := uint32(32000000)
+	wantPayload := fixedExcessiveBlockSize
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msgcfcheckpt.go
+++ b/wire/msgcfcheckpt.go
@@ -149,7 +149,7 @@ func (msg *MsgCFCheckpt) Command() string {
 func (msg *MsgCFCheckpt) MaxPayloadLength(pver uint32) uint32 {
 	// Message size depends on the blockchain height, so return general limit
 	// for all messages.
-	return MaxMessagePayload
+	return maxMessagePayload()
 }
 
 // NewMsgCFCheckpt returns a new bitcoin cfheaders message that conforms to

--- a/wire/msgmerkleblock_test.go
+++ b/wire/msgmerkleblock_test.go
@@ -38,7 +38,7 @@ func TestMerkleBlock(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
-	wantPayload := uint32(32000000)
+	wantPayload := fixedExcessiveBlockSize
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+
@@ -48,7 +48,7 @@ func TestMerkleBlock(t *testing.T) {
 
 	// Load maxTxPerBlock hashes
 	data := make([]byte, 32)
-	for i := 0; i < maxTxPerBlock; i++ {
+	for i := uint32(0); i < maxTxPerBlock(); i++ {
 		rand.Read(data)
 		hash, err := chainhash.NewHash(data)
 		if err != nil {
@@ -101,7 +101,7 @@ func TestMerkleBlock(t *testing.T) {
 	// Force too many flag bytes to test maxFlagsPerMerkleBlock.
 	// Reset the number of hashes back to a valid value.
 	msg.Hashes = msg.Hashes[len(msg.Hashes)-1:]
-	msg.Flags = make([]byte, maxFlagsPerMerkleBlock+1)
+	msg.Flags = make([]byte, int(maxFlagsPerMerkleBlock())+1)
 	err = msg.BchEncode(&buf, pver, enc)
 	if err == nil {
 		t.Errorf("encode of MsgMerkleBlock succeeded with too many " +
@@ -330,7 +330,7 @@ func TestMerkleBlockOverflowErrors(t *testing.T) {
 	// Create bytes for a merkle block that claims to have more than the max
 	// allowed tx hashes.
 	var buf bytes.Buffer
-	WriteVarInt(&buf, pver, maxTxPerBlock+1)
+	WriteVarInt(&buf, pver, uint64(maxTxPerBlock())+1)
 	numHashesOffset := 84
 	exceedMaxHashes := make([]byte, numHashesOffset)
 	copy(exceedMaxHashes, merkleBlockOneBytes[:numHashesOffset])
@@ -339,7 +339,7 @@ func TestMerkleBlockOverflowErrors(t *testing.T) {
 	// Create bytes for a merkle block that claims to have more than the max
 	// allowed flag bytes.
 	buf.Reset()
-	WriteVarInt(&buf, pver, maxFlagsPerMerkleBlock+1)
+	WriteVarInt(&buf, pver, uint64(maxFlagsPerMerkleBlock())+1)
 	numFlagBytesOffset := 117
 	exceedMaxFlagBytes := make([]byte, numFlagBytesOffset)
 	copy(exceedMaxFlagBytes, merkleBlockOneBytes[:numFlagBytesOffset])

--- a/wire/msgreject.go
+++ b/wire/msgreject.go
@@ -169,7 +169,7 @@ func (msg *MsgReject) MaxPayloadLength(pver uint32) uint32 {
 		// Unfortunately the bitcoin protocol does not enforce a sane
 		// limit on the length of the reason, so the max payload is the
 		// overall maximum message payload.
-		plen = MaxMessagePayload
+		plen = maxMessagePayload()
 	}
 
 	return plen

--- a/wire/msgreject_test.go
+++ b/wire/msgreject_test.go
@@ -77,7 +77,7 @@ func TestRejectLatest(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	wantPayload := uint32(MaxMessagePayload)
+	wantPayload := uint32(maxMessagePayload())
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -35,7 +35,7 @@ func TestTx(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	wantPayload := uint32(32000000)
+	wantPayload := fixedExcessiveBlockSize
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+


### PR DESCRIPTION
Fixes #102, #110 

This is more of a request for feedback. As described in #102, the race condition is not such a big deal - it's more of a test issue. However it showed more importantly that there are many fake static configuration values as documented in #110.

I tried 3 ways to fix it with minimal changes:

1. Threading the EBS dependency into everything that needs it. This just made the `wire` package a mess and made it harder to use as well.

1. (This PR) Initializing EBS in the wire package explicitly. This is a pain because everyone that uses it has to initialize the package. However, it turned out to be the cleanest fix that I found.

1. [Refactor a new `config` package](https://github.com/gcash/bchd/compare/master...emergent-reasons:isolate-config) so that any package can get EBS and other config values. This would have the benefit of reducing quite a bit of redundant configuration loading code in the commands. It also would be nice to have config decoupled from CLI code. However, I ran into an import cycle (`wire-->config-->chaincfg-->wire` and stopped at that point.

I am hoping someone has a more elegant / simple way to solve these issues, especially #110.