### PR TITLE
make sure to unspend entries in the cache when reorging

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -879,6 +879,10 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		return nil
 	}
 
+	// The rest of the reorg depends on all STXOs already being in the database
+	// so we flush before reorg
+	b.utxoCache.Flush(FlushRequired, b.BestSnapshot())
+
 	// Ensure the provided nodes match the current best chain.
 	tip := b.bestChain.Tip()
 	if detachNodes.Len() != 0 {

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -413,13 +413,10 @@ func TestUtxoCache_Reorg(t *testing.T) {
 	// Spend all spendable outs and confirm with a block.
 	var forkSpendables []*spendableOut
 	b1a, forkSpendables := addBlock(chain, b0, spendableOuts)
-	b2a, forkSpendables := addBlock(chain, b1a, forkSpendables)
+	_, forkSpendables = addBlock(chain, b1a, forkSpendables)
 
-	if err := chain.FlushCachedState(FlushRequired); err != nil {
-		t.Fatalf("unexpected error while flushing cache: %v", err)
-	}
-	assertConsistencyState(t, chain, ucsConsistent, b2a.Hash())
-	assertNbEntriesOnDisk(t, chain, len(forkSpendables))
+	// leave the spent outs in the cache which lets us exercise
+	// un-spending entries both in the db and in the utxocache
 
 	// Build an alternative chain of 3 blocks.
 	b1b, spendable := addBlock(chain, b0, nil)

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -396,40 +396,64 @@ func TestUtxoCache_Reorg(t *testing.T) {
 	defer tearDown()
 	tip := bchutil.NewBlock(params.GenesisBlock)
 
-	// First make two blocks that create spendable outputs.
-	var spendableOuts []*spendableOut
-	tip, spendableOuts = addBlock(chain, tip, spendableOuts)
-	tip, spendableOuts = addBlock(chain, tip, spendableOuts)
-	t.Log(spew.Sdump(spendableOuts))
+	// Create base blocks 1 and 2 that will not be reorged.
+	// Spend the outputs of block 1.
+	var emptySpendableOuts []*spendableOut
+	b1, spendableOuts1 := addBlock(chain, tip, emptySpendableOuts)
+	b2, spendableOuts2 := addBlock(chain, b1, spendableOuts1)
+	t.Log(spew.Sdump(spendableOuts2))
+	//                 db       cache
+	// block 1:                  stxo
+	// block 2:                  utxo
+
+	// Commit the two base blocks to DB
+	if err := chain.FlushCachedState(FlushRequired); err != nil {
+		t.Fatalf("unexpected error while flushing cache: %v", err)
+	}
+	//                 db       cache
+	// block 1:       stxo
+	// block 2:       utxo
+	assertConsistencyState(t, chain, ucsConsistent, b2.Hash())
+	assertNbEntriesOnDisk(t, chain, len(spendableOuts2))
+
+	// Add blocks 3 and 4 that will be orphaned.
+	// Spend the outputs of block 2 and 3a.
+	b3a, spendableOuts3 := addBlock(chain, b2, spendableOuts2)
+	addBlock(chain, b3a, spendableOuts3)
+	//                 db       cache
+	// block 1:       stxo
+	// block 2:       utxo       stxo      << these are left spent without flush
+	// ---
+	// block 3a:                 stxo
+	// block 4a:                 utxo
+
+	// Build an alternative chain of blocks 3 and 4 + new 5th, spending none of the outputs
+	b3b, altSpendableOuts3 := addBlock(chain, b2, nil)
+	b4b, altSpendableOuts4 := addBlock(chain, b3b, nil)
+	b5b, altSpendableOuts5 := addBlock(chain, b4b, nil)
+	totalSpendableOuts := spendableOuts2[:]
+	totalSpendableOuts = append(totalSpendableOuts, altSpendableOuts3...)
+	totalSpendableOuts = append(totalSpendableOuts, altSpendableOuts4...)
+	totalSpendableOuts = append(totalSpendableOuts, altSpendableOuts5...)
+	t.Log(spew.Sdump(totalSpendableOuts))
+	//                 db       cache
+	// block 1:       stxo
+	// block 2:       utxo       utxo     << now they should become utxo
+	// ---
+	// block 3b:                 utxo
+	// block 4b:                 utxo
+	// block 5b:                 utxo
 
 	if err := chain.FlushCachedState(FlushRequired); err != nil {
 		t.Fatalf("unexpected error while flushing cache: %v", err)
 	}
-	assertConsistencyState(t, chain, ucsConsistent, tip.Hash())
-	assertNbEntriesOnDisk(t, chain, len(spendableOuts))
-
-	b0 := tip
-
-	// Spend all spendable outs and confirm with a block.
-	var forkSpendables []*spendableOut
-	b1a, forkSpendables := addBlock(chain, b0, spendableOuts)
-	_, forkSpendables = addBlock(chain, b1a, forkSpendables)
-
-	// leave the spent outs in the cache which lets us exercise
-	// un-spending entries both in the db and in the utxocache
-
-	// Build an alternative chain of 3 blocks.
-	b1b, spendable := addBlock(chain, b0, nil)
-	spendableOuts = append(spendableOuts, spendable...)
-	b2b, spendable := addBlock(chain, b1b, nil)
-	spendableOuts = append(spendableOuts, spendable...)
-	b3b, spendable := addBlock(chain, b2b, nil)
-	spendableOuts = append(spendableOuts, spendable...)
-	t.Log(spew.Sdump(spendableOuts))
-
-	if err := chain.FlushCachedState(FlushRequired); err != nil {
-		t.Fatalf("unexpected error while flushing cache: %v", err)
-	}
-	assertConsistencyState(t, chain, ucsConsistent, b3b.Hash())
-	assertNbEntriesOnDisk(t, chain, len(spendableOuts))
+	//                 db       cache
+	// block 1:       stxo
+	// block 2:       utxo
+	// ---
+	// block 3b:      utxo
+	// block 4b:      utxo
+	// block 5b:      utxo
+	assertConsistencyState(t, chain, ucsConsistent, b5b.Hash())
+	assertNbEntriesOnDisk(t, chain, len(totalSpendableOuts))
 }


### PR DESCRIPTION
As I understand it, the reorg seems to have failed to un-spend some entries.

My best guess was that cached spends were not being included in the un-spend loop of the reorg function.

This is my naive attempt at a solution. Just flush the cache before reorging.

1. Not sure I got the problem right in the first place.
1. It seems there must be a more sophisticated way to include cache spends in the unmark phase, but I couldn't find a way to do it. The code is centered around the content in the block so the flush was an easy way to get the result I wanted.

If this is off-base, any feedback would be appreciated.