### PR TITLE
[Bug] Fix 0% progress logging problem

### DIFF
--- a/netsync/blocklogger.go
+++ b/netsync/blocklogger.go
@@ -78,7 +78,10 @@ func (b *blockProgressLogger) LogBlockHeight(block *bchutil.Block, bestHeight ui
 
 	var heightStr string
 
-	if uint64(block.Height()) >= bestHeight {
+	if bestHeight == 0 {
+		// We don't have a best height due to no sync peer. Don't log the percentage.
+		heightStr = fmt.Sprintf("%d", block.Height())
+	} else if uint64(block.Height()) >= bestHeight {
 		// sync is up to date so shorten the height output
 		heightStr = fmt.Sprintf("%d (%.2f%%)", block.Height(), progress)
 	} else {


### PR DESCRIPTION
Saw the following in my logs:

```
I  2018-11-17 20:55:05.718 [INF] SYNC: Processed 1 block in 26m14.56s (7545 transactions, height 557081 (0.00%), 2018-11-17 20:54:18 +0000 UTC, ~61 MiB cache)
 
I  2018-11-17 20:28:51.155 [INF] SYNC: Processed 1 block in 12m18.28s (37 transactions, height 557080 (0.00%), 2018-11-17 20:27:59 +0000 UTC, ~57 MiB cache)
 
I  2018-11-17 20:16:32.869 [INF] SYNC: Processed 1 block in 7m17.83s (9 transactions, height 557079 (0.00%), 2018-11-17 20:16:05 +0000 UTC, ~57 MiB cache)
 
I  2018-11-17 20:09:15.028 [INF] SYNC: Processed 1 block in 2m45.08s (999 transactions, height 557078 (100.00%), 2018-11-17 20:09:09 +0000 UTC, ~57 MiB cache)
 
I  2018-11-17 20:06:29.940 [INF] SYNC: Processed 1 block in 29m0.76s (36 transactions, height 557077 (100.00%), 2018-11-17 20:05:51 +0000 UTC, ~57 MiB cache)
 ```

This just makes sure we never show 0.00% if we can't find a correct percentage.