### PR TITLE
[Bug[ Fix double printed help screen.

### DIFF
--- a/bchd.go
+++ b/bchd.go
@@ -19,6 +19,8 @@ import (
 	"github.com/gcash/bchd/database"
 	"github.com/gcash/bchd/limits"
 	"github.com/gcash/bchd/version"
+
+	flags "github.com/jessevdk/go-flags"
 )
 
 const (
@@ -46,6 +48,10 @@ func bchdMain(serverChan chan<- *server) error {
 	// initializes logging and configures it accordingly.
 	tcfg, _, err := loadConfig()
 	if err != nil {
+		// If it is a help error we have already handled it.
+		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
+			return nil
+		}
 		return err
 	}
 	cfg = tcfg

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gcash/bchd/peer"
 	"github.com/gcash/bchd/version"
 	"github.com/gcash/bchutil"
+
 	flags "github.com/jessevdk/go-flags"
 )
 

--- a/kube/bchd-deployment.yml
+++ b/kube/bchd-deployment.yml
@@ -29,7 +29,7 @@ spec:
               key: rpcpass
         image: zquestz/bchd:latest
         command: ["bchd"]
-        args: ["-u", "$(BCHD_RPC_USER)", "-P", "$(BCHD_RPC_PASSWORD)", "--addrindex", "--txindex", "-b", "/data", "-C", "/data/bchd.conf"]
+        args: ["-u", "$(BCHD_RPC_USER)", "-P", "$(BCHD_RPC_PASSWORD)", "--addrindex", "--txindex", "-b", "/data", "-C", "/data/bchd.conf", "--externalip", "35.202.172.160"]
         name: bchd
         volumeMounts:
           - mountPath: /data

--- a/kube/bchd-deployment.yml
+++ b/kube/bchd-deployment.yml
@@ -29,7 +29,7 @@ spec:
               key: rpcpass
         image: zquestz/bchd:latest
         command: ["bchd"]
-        args: ["-u", "$(BCHD_RPC_USER)", "-P", "$(BCHD_RPC_PASSWORD)", "--addrindex", "--txindex", "-b", "/data", "-C", "/data/bchd.conf", "--externalip", "35.202.172.160"]
+        args: ["-u", "$(BCHD_RPC_USER)", "-P", "$(BCHD_RPC_PASSWORD)", "--addrindex", "--txindex", "-b", "/data", "-C", "/data/bchd.conf", "--externalip", "35.202.172.160", "--maxpeers", "512"]
         name: bchd
         volumeMounts:
           - mountPath: /data

--- a/kube/bchd-deployment.yml
+++ b/kube/bchd-deployment.yml
@@ -4,7 +4,7 @@ metadata:
   namespace: default
   labels:
     service: bchd
-    version: 0.12.0-beta2
+    version: 0.13.0-beta
   name: bchd
 spec:
   strategy:


### PR DESCRIPTION
Noticed that when you run `bchd -h` it was printing the help twice. This just fixes the behavior and gives us a nice help screen.