### PR TITLE
[Bug] Fix double printed help

### DIFF
--- a/bchd.go
+++ b/bchd.go
@@ -19,6 +19,8 @@ import (
 	"github.com/gcash/bchd/database"
 	"github.com/gcash/bchd/limits"
 	"github.com/gcash/bchd/version"
+
+	flags "github.com/jessevdk/go-flags"
 )
 
 const (
@@ -46,6 +48,10 @@ func bchdMain(serverChan chan<- *server) error {
 	// initializes logging and configures it accordingly.
 	tcfg, _, err := loadConfig()
 	if err != nil {
+		// If it is a help error we have already handled it.
+		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
+			return nil
+		}
 		return err
 	}
 	cfg = tcfg

--- a/bchd.go
+++ b/bchd.go
@@ -19,8 +19,6 @@ import (
 	"github.com/gcash/bchd/database"
 	"github.com/gcash/bchd/limits"
 	"github.com/gcash/bchd/version"
-
-	flags "github.com/jessevdk/go-flags"
 )
 
 const (
@@ -48,10 +46,6 @@ func bchdMain(serverChan chan<- *server) error {
 	// initializes logging and configures it accordingly.
 	tcfg, _, err := loadConfig()
 	if err != nil {
-		// If it is a help error we have already handled it.
-		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
-			return nil
-		}
 		return err
 	}
 	cfg = tcfg
@@ -335,7 +329,6 @@ func main() {
 
 	// Work around defer not working after os.Exit()
 	if err := bchdMain(nil); err != nil {
-		fmt.Fprintf(os.Stderr, "error running node: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gcash/bchd/peer"
 	"github.com/gcash/bchd/version"
 	"github.com/gcash/bchutil"
+
 	flags "github.com/jessevdk/go-flags"
 )
 


### PR DESCRIPTION
When you run `bchd -h` it was printing the help twice. This just fixes the output so it only shows once. The final error from `bchMain` doesn't need to be printed, upstream it prints what is needed.