### PR TITLE
Avoid naming collisions

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -719,8 +719,8 @@ func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.S
 func ipString(na *wire.NetAddress) string {
 	if IsOnionCatTor(na) {
 		// We know now that na.IP is long enough.
-		base32 := base32.StdEncoding.EncodeToString(na.IP[6:])
-		return strings.ToLower(base32) + ".onion"
+		base32str := base32.StdEncoding.EncodeToString(na.IP[6:])
+		return strings.ToLower(base32str) + ".onion"
 	}
 
 	return na.IP.String()

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -259,8 +259,8 @@ func GroupKey(na *wire.NetAddress) string {
 		// teredo tunnels have the last 4 bytes as the v4 address XOR
 		// 0xff.
 		ip := net.IP(make([]byte, 4))
-		for i, byte_ := range na.IP[12:16] {
-			ip[i] = byte_ ^ 0xff
+		for i, ipByte := range na.IP[12:16] {
+			ip[i] = ipByte ^ 0xff
 		}
 		return ip.Mask(net.CIDRMask(16, 32)).String()
 	}

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -259,8 +259,8 @@ func GroupKey(na *wire.NetAddress) string {
 		// teredo tunnels have the last 4 bytes as the v4 address XOR
 		// 0xff.
 		ip := net.IP(make([]byte, 4))
-		for i, byte := range na.IP[12:16] {
-			ip[i] = byte ^ 0xff
+		for i, byte_ := range na.IP[12:16] {
+			ip[i] = byte_ ^ 0xff
 		}
 		return ip.Mask(net.CIDRMask(16, 32)).String()
 	}

--- a/cmd/bchctl/config.go
+++ b/cmd/bchctl/config.go
@@ -68,7 +68,7 @@ func listCommands() {
 			continue
 		}
 
-		// Categorize the command based on the usage usageFlags.
+		// Categorize the command based on the usageFlags.
 		category := categoryChain
 		if usageFlags&btcjson.UFWalletOnly != 0 {
 			category = categoryWallet

--- a/cmd/bchctl/config.go
+++ b/cmd/bchctl/config.go
@@ -49,7 +49,7 @@ func listCommands() {
 	cmdMethods := btcjson.RegisteredCmdMethods()
 	categorized := make([][]string, numCategories)
 	for _, method := range cmdMethods {
-		flags, err := btcjson.MethodUsageFlags(method)
+		usageFlags, err := btcjson.MethodUsageFlags(method)
 		if err != nil {
 			// This should never happen since the method was just
 			// returned from the package, but be safe.
@@ -57,7 +57,7 @@ func listCommands() {
 		}
 
 		// Skip the commands that aren't usable from this utility.
-		if flags&unusableFlags != 0 {
+		if usageFlags&unusableFlags != 0 {
 			continue
 		}
 
@@ -68,9 +68,9 @@ func listCommands() {
 			continue
 		}
 
-		// Categorize the command based on the usage flags.
+		// Categorize the command based on the usage usageFlags.
 		category := categoryChain
-		if flags&btcjson.UFWalletOnly != 0 {
+		if usageFlags&btcjson.UFWalletOnly != 0 {
 			category = categoryWallet
 		}
 		categorized[category] = append(categorized[category], usage)


### PR DESCRIPTION
Fixes possible bugs due to naming collisions with built-in types and imported package names.