### PR TITLE
[Bug] Add BestLocalAddress when responding to getAddr messages

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -2036,7 +2036,8 @@ func (p *Peer) localVersionMsg() (*wire.MsgVersion, error) {
 		ourNA = p.cfg.AddrMe
 	} else {
 		ourNA = &wire.NetAddress{
-			Services: p.cfg.Services,
+			Services:  p.cfg.Services,
+			Timestamp: time.Now(),
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -1262,6 +1262,17 @@ func (sp *serverPeer) OnGetAddr(_ *peer.Peer, msg *wire.MsgGetAddr) {
 	// Get the current known addresses from the address manager.
 	addrCache := sp.server.addrManager.AddressCache()
 
+	// Add our best net address for peers to discover us. If the port
+	// is 0 that indicates no worthy address was found, therefore
+	// we do not broadcast it. We also must trim the cache by one
+	// entry if we insert a record to prevent sending past the max
+	// send size.
+	bestAddress := sp.server.addrManager.GetBestLocalAddress(sp.NA())
+	if bestAddress.Port != 0 {
+		addrCache = addrCache[1:]
+		addrCache = append(addrCache, bestAddress)
+	}
+
 	// Push the addresses.
 	sp.pushAddrMsg(addrCache)
 }


### PR DESCRIPTION
Currently, we don't send our own IP when receiving getAddr messages, this makes sure to include it in the address list.

Testing this now. =)

EDIT: And I have been seen!

```
"35.202.172.160:8333":{"version":"\/bchd:0.13.0\/","country":"US","height":557436,"flags":293}
```