### PR TITLE
[Feature] Add configuration option for targetOutboundPeers

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,6 +65,7 @@ const (
 	defaultUtxoCacheMaxSizeMiB     = 450
 	defaultMinSyncPeerNetworkSpeed = 51200
 	defaultPruneDepth              = 4320
+	defaultTargetOutboundPeers     = uint32(8)
 	minPruneDepth                  = 288
 )
 
@@ -178,6 +179,7 @@ type config struct {
 	RejectNonStd            bool          `long:"rejectnonstd" description:"Reject non-standard transactions regardless of the default settings for the active network."`
 	Prune                   bool          `long:"prune" description:"Delete historical blocks from the chain. A buffer of blocks will be retained in case of a reorg."`
 	PruneDepth              uint32        `long:"prunedepth" description:"The number of blocks to retain when running in pruned mode. Cannot be less than 288."`
+	TargetOutboundPeers     uint32        `long:"targetoutboundpeers" description:"number of outbound connections to maintain"`
 	lookup                  func(string) ([]net.IP, error)
 	oniondial               func(string, string, time.Duration) (net.Conn, error)
 	dial                    func(string, string, time.Duration) (net.Conn, error)
@@ -447,6 +449,7 @@ func loadConfig() (*config, []string, error) {
 		TxIndex:                 defaultTxIndex,
 		AddrIndex:               defaultAddrIndex,
 		PruneDepth:              defaultPruneDepth,
+		TargetOutboundPeers:     defaultTargetOutboundPeers,
 	}
 
 	// Service options which are only added on Windows.

--- a/server.go
+++ b/server.go
@@ -51,9 +51,6 @@ const (
 	// required to be supported by outbound peers.
 	defaultRequiredServices = wire.SFNodeNetwork
 
-	// defaultTargetOutbound is the default number of outbound peers to target.
-	defaultTargetOutbound = 8
-
 	// connectionRetryInterval is the base amount of time to wait in between
 	// retries when connecting to persistent peers.  It is adjusted by the
 	// number of retries such that there is a retry backoff.
@@ -2837,15 +2834,15 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 
 	// Create a connection manager.
-	targetOutbound := defaultTargetOutbound
-	if cfg.MaxPeers < targetOutbound {
-		targetOutbound = cfg.MaxPeers
+	targetOutbound := cfg.TargetOutboundPeers
+	if cfg.MaxPeers < int(targetOutbound) {
+		targetOutbound = uint32(cfg.MaxPeers)
 	}
 	cmgr, err := connmgr.New(&connmgr.Config{
 		Listeners:      listeners,
 		OnAccept:       s.inboundPeerConnected,
 		RetryDuration:  connectionRetryInterval,
-		TargetOutbound: uint32(targetOutbound),
+		TargetOutbound: targetOutbound,
 		Dial:           bchdDial,
 		OnConnection:   s.outboundPeerConnected,
 		GetNewAddress:  newAddressFunc,


### PR DESCRIPTION
Adds a new configuration option `targetoutboundpeers` to set the connection target for outbound peers. Many nodes will want to be above 8, including mine. =)