### PR TITLE
Fix utxo reorg bug

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1014,7 +1014,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 			if err != nil {
 				return err
 			}
-			err = connectTransactions(view, block, nil, false)
+			err = connectTransactions(view, block, nil, true)
 			if err != nil {
 				return err
 			}

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -455,6 +455,14 @@ func (s *utxoCache) Commit(view *UtxoViewpoint) error {
 			continue
 		}
 
+		// It's possible if we disconnected this UTXO at some point, removing it from
+		// the UTXO set, only to have a future block add it back. In that case it could
+		// be going from being marked spent to needing to be marked unspent so we handle
+		// that case by overriding here.
+		if ourEntry.IsSpent() && !entry.IsSpent() {
+			ourEntry = entry
+		}
+
 		// Store the entry we don't know.
 		if err := s.addEntry(outpoint, ourEntry, false); err != nil {
 			return err


### PR DESCRIPTION
We hit a bug with the following setup. Block 559307(a) was mined creating a new
utxo (u). An alternate block 559307(b) was mined which did not create u. Subsequently
559308 was mined on top of b which did create u again. So during the reorg u
needed to go from unspent to spent(removed) when block a was disconnected, then
back to unspent again when block 559308 was connected. However, the utxocache
commit() function did not have the ability to override a utxo previously marked
as spent back into an unspent state and thus u was left marked as spent. When
559309 was mined spending u, it failed to validate because u was erroneously marked
as spent already.

This commit patches the commit() function to allow overriding from spent to
unspent.