### PR TITLE
Bump version to 0.13.0-beta2

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -22,7 +22,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	AppPreRelease = "beta"
+	AppPreRelease = "beta2"
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
When fastsync is merged, we should probably bump to beta2. =)