### PR TITLE
BUGFIX: Don't attempt deep reorg unless using --force flag.

### DIFF
--- a/cmd/utxotool/config.go
+++ b/cmd/utxotool/config.go
@@ -121,6 +121,7 @@ func loadConfig() (*config, []string, error) {
 			"rolled back are held in memory. If you wish to continue use --force."
 		err := fmt.Errorf(str, funcName, activeNetParams.Checkpoints[len(activeNetParams.Checkpoints)-1].Height)
 		fmt.Fprintln(os.Stderr, err)
+		return nil, nil, err
 	}
 
 	// Validate database type.


### PR DESCRIPTION
Currently we show a warning but don't don't actually alter our behavior in any way. This changes that by returning and exiting the process with an error code.