### PR TITLE
WIP: fix MaxSigOps

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -33,7 +33,7 @@ import (
 const (
 	// Intentionally defined here rather than using constants from codebase
 	// to ensure consensus changes are detected.
-	maxBlockSigOps       = 20000
+	maxBlockSigOpsPerMB  = 20000
 	maxBlockSize         = 1000000
 	minCoinbaseScriptLen = 2
 	maxCoinbaseScriptLen = 100
@@ -1071,9 +1071,9 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//   ... -> b5(2) -> b12(3) -> b13(4) -> b15(5)
 	//   \-> b3(1) -> b4(2)
 	g.setTip("b13")
-	manySigOps := repeatOpcode(txscript.OP_CHECKSIG, maxBlockSigOps)
+	manySigOps := repeatOpcode(txscript.OP_CHECKSIG, maxBlockSigOpsPerMB)
 	g.nextBlock("b15", outs[5], replaceSpendScript(manySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB)
 	accepted()
 
 	// Attempt to add block with more than max allowed signature operations
@@ -1082,9 +1082,9 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//   ... -> b5(2) -> b12(3) -> b13(4) -> b15(5)
 	//   \                                         \-> b16(7)
 	//    \-> b3(1) -> b4(2)
-	tooManySigOps := repeatOpcode(txscript.OP_CHECKSIG, maxBlockSigOps+1)
+	tooManySigOps := repeatOpcode(txscript.OP_CHECKSIG, maxBlockSigOpsPerMB+1)
 	g.nextBlock("b16", outs[6], replaceSpendScript(tooManySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps + 1)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB + 1)
 	rejected(blockchain.ErrTxTooManySigOps)
 
 	// ---------------------------------------------------------------------
@@ -1223,9 +1223,9 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//   ... -> b30(7) -> b31(8)
 	//
 	// OP_CHECKMULTISIG counts for 20 sigops.
-	manySigOps = repeatOpcode(txscript.OP_CHECKMULTISIG, maxBlockSigOps/20)
+	manySigOps = repeatOpcode(txscript.OP_CHECKMULTISIG, maxBlockSigOpsPerMB/20)
 	g.nextBlock("b31", outs[8], replaceSpendScript(manySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB)
 	accepted()
 
 	// Create block with more than max allowed signature operations using
@@ -1235,19 +1235,19 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//                \-> b32(9)
 	//
 	// OP_CHECKMULTISIG counts for 20 sigops.
-	tooManySigOps = repeatOpcode(txscript.OP_CHECKMULTISIG, maxBlockSigOps/20)
+	tooManySigOps = repeatOpcode(txscript.OP_CHECKMULTISIG, maxBlockSigOpsPerMB/20)
 	tooManySigOps = append(tooManySigOps, txscript.OP_CHECKSIG)
 	g.nextBlock("b32", outs[9], replaceSpendScript(tooManySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps + 1)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB + 1)
 	rejected(blockchain.ErrTxTooManySigOps)
 
 	// Create block with max signature operations as OP_CHECKMULTISIGVERIFY.
 	//
 	//   ... -> b31(8) -> b33(9)
 	g.setTip("b31")
-	manySigOps = repeatOpcode(txscript.OP_CHECKMULTISIGVERIFY, maxBlockSigOps/20)
+	manySigOps = repeatOpcode(txscript.OP_CHECKMULTISIGVERIFY, maxBlockSigOpsPerMB/20)
 	g.nextBlock("b33", outs[9], replaceSpendScript(manySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB)
 	accepted()
 
 	// Create block with more than max allowed signature operations using
@@ -1256,10 +1256,10 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//   ... -> b33(9)
 	//                \-> b34(10)
 	//
-	tooManySigOps = repeatOpcode(txscript.OP_CHECKMULTISIGVERIFY, maxBlockSigOps/20)
+	tooManySigOps = repeatOpcode(txscript.OP_CHECKMULTISIGVERIFY, maxBlockSigOpsPerMB/20)
 	tooManySigOps = append(manySigOps, txscript.OP_CHECKSIG)
 	g.nextBlock("b34", outs[10], replaceSpendScript(tooManySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps + 1)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB + 1)
 	rejected(blockchain.ErrTxTooManySigOps)
 
 	// Create block with max signature operations as OP_CHECKSIGVERIFY.
@@ -1267,9 +1267,9 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//   ... -> b33(9) -> b35(10)
 	//
 	g.setTip("b33")
-	manySigOps = repeatOpcode(txscript.OP_CHECKSIGVERIFY, maxBlockSigOps)
+	manySigOps = repeatOpcode(txscript.OP_CHECKSIGVERIFY, maxBlockSigOpsPerMB)
 	g.nextBlock("b35", outs[10], replaceSpendScript(manySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB)
 	accepted()
 
 	// Create block with more than max allowed signature operations using
@@ -1278,9 +1278,9 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//   ... -> b35(10)
 	//                 \-> b36(11)
 	//
-	tooManySigOps = repeatOpcode(txscript.OP_CHECKSIGVERIFY, maxBlockSigOps+1)
+	tooManySigOps = repeatOpcode(txscript.OP_CHECKSIGVERIFY, maxBlockSigOpsPerMB+1)
 	g.nextBlock("b36", outs[11], replaceSpendScript(tooManySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps + 1)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB + 1)
 	rejected(blockchain.ErrTxTooManySigOps)
 
 	// ---------------------------------------------------------------------
@@ -1330,7 +1330,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		// operations in those redeem scripts will be more than the
 		// max allowed per block.
 		p2shScript := payToScriptHashScript(redeemScript)
-		txnsNeeded := (maxBlockSigOps / redeemScriptSigOps) + 1
+		txnsNeeded := (maxBlockSigOpsPerMB / redeemScriptSigOps) + 1
 		prevTx := b.Transactions[1]
 		for i := 0; i < txnsNeeded; i++ {
 			prevTx = createSpendTxForTx(prevTx, lowFee)
@@ -1339,7 +1339,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 			b.AddTransaction(prevTx)
 		}
 	})
-	g.assertTipBlockNumTxns((maxBlockSigOps / redeemScriptSigOps) + 3)
+	g.assertTipBlockNumTxns((maxBlockSigOpsPerMB / redeemScriptSigOps) + 3)
 	accepted()
 
 	// Create a block with more than max allowed signature operations where
@@ -1349,7 +1349,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//                            \-> b40(12)
 	g.setTip("b39")
 	g.nextBlock("b40", outs[12], func(b *wire.MsgBlock) {
-		txnsNeeded := (maxBlockSigOps / redeemScriptSigOps)
+		txnsNeeded := (maxBlockSigOpsPerMB / redeemScriptSigOps)
 		for i := 0; i < txnsNeeded; i++ {
 			// Create a signed transaction that spends from the
 			// associated p2sh output in b39.
@@ -1368,7 +1368,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		// Create a final tx that includes a non-pay-to-script-hash
 		// output with the number of signature operations needed to push
 		// the block one over the max allowed.
-		fill := maxBlockSigOps - (txnsNeeded * redeemScriptSigOps) + 1
+		fill := maxBlockSigOpsPerMB - (txnsNeeded * redeemScriptSigOps) + 1
 		finalTx := b.Transactions[len(b.Transactions)-1]
 		tx := createSpendTxForTx(finalTx, lowFee)
 		tx.TxOut[0].PkScript = repeatOpcode(txscript.OP_CHECKSIG, fill)
@@ -1382,7 +1382,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//   ... -> b35(10) -> b39(11) -> b41(12)
 	g.setTip("b39")
 	g.nextBlock("b41", outs[12], func(b *wire.MsgBlock) {
-		txnsNeeded := (maxBlockSigOps / redeemScriptSigOps)
+		txnsNeeded := (maxBlockSigOpsPerMB / redeemScriptSigOps)
 		for i := 0; i < txnsNeeded; i++ {
 			spend := makeSpendableOutForTx(b39.Transactions[i+2], 2)
 			tx := createSpendTx(&spend, lowFee)
@@ -1399,7 +1399,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		// Create a final tx that includes a non-pay-to-script-hash
 		// output with the number of signature operations needed to push
 		// the block to exactly the max allowed.
-		fill := maxBlockSigOps - (txnsNeeded * redeemScriptSigOps)
+		fill := maxBlockSigOpsPerMB - (txnsNeeded * redeemScriptSigOps)
 		if fill == 0 {
 			return
 		}
@@ -1894,7 +1894,9 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	// The script generated consists of the following form:
 	//
 	//  Comment assumptions:
-	//    maxBlockSigOps = 20000
+	//    block size <= 1MB
+	//    maxTxSigOps = 20000
+	//    maxBlockSigOpsPerMB = 20000
 	//    maxScriptElementSize = 520
 	//
 	//  [0-19999]    : OP_CHECKSIG
@@ -1905,13 +1907,13 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//
 	//   ... -> b69(20)
 	//                 \-> b70(21)
-	scriptSize := maxBlockSigOps + 5 + (maxScriptElementSize + 1) + 1
+	scriptSize := maxBlockSigOpsPerMB + 5 + (maxScriptElementSize + 1) + 1
 	tooManySigOps = repeatOpcode(txscript.OP_CHECKSIG, scriptSize)
-	tooManySigOps[maxBlockSigOps] = txscript.OP_PUSHDATA4
-	binary.LittleEndian.PutUint32(tooManySigOps[maxBlockSigOps+1:],
+	tooManySigOps[maxBlockSigOpsPerMB] = txscript.OP_PUSHDATA4
+	binary.LittleEndian.PutUint32(tooManySigOps[maxBlockSigOpsPerMB+1:],
 		maxScriptElementSize+1)
 	g.nextBlock("b70", outs[21], replaceSpendScript(tooManySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps + 1)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB + 1)
 	rejected(blockchain.ErrTxTooManySigOps)
 
 	// Create block with more than max allowed signature operations such
@@ -1922,12 +1924,12 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//   ... -> b69(20)
 	//                 \-> b71(21)
 	g.setTip("b69")
-	scriptSize = maxBlockSigOps + 5 + maxScriptElementSize + 1
+	scriptSize = maxBlockSigOpsPerMB + 5 + maxScriptElementSize + 1
 	tooManySigOps = repeatOpcode(txscript.OP_CHECKSIG, scriptSize)
-	tooManySigOps[maxBlockSigOps+1] = txscript.OP_PUSHDATA4
-	binary.LittleEndian.PutUint32(tooManySigOps[maxBlockSigOps+2:], 0xffffffff)
+	tooManySigOps[maxBlockSigOpsPerMB+1] = txscript.OP_PUSHDATA4
+	binary.LittleEndian.PutUint32(tooManySigOps[maxBlockSigOpsPerMB+2:], 0xffffffff)
 	g.nextBlock("b71", outs[21], replaceSpendScript(tooManySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps + 1)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB + 1)
 	rejected(blockchain.ErrTxTooManySigOps)
 
 	// Create block with the max allowed signature operations such that all
@@ -1938,12 +1940,12 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//
 	//   ... -> b69(20) -> b72(21)
 	g.setTip("b69")
-	scriptSize = maxBlockSigOps + 5 + maxScriptElementSize
+	scriptSize = maxBlockSigOpsPerMB + 5 + maxScriptElementSize
 	manySigOps = repeatOpcode(txscript.OP_CHECKSIG, scriptSize)
-	manySigOps[maxBlockSigOps] = txscript.OP_PUSHDATA4
-	binary.LittleEndian.PutUint32(manySigOps[maxBlockSigOps+1:], 0xffffffff)
+	manySigOps[maxBlockSigOpsPerMB] = txscript.OP_PUSHDATA4
+	binary.LittleEndian.PutUint32(manySigOps[maxBlockSigOpsPerMB+1:], 0xffffffff)
 	g.nextBlock("b72", outs[21], replaceSpendScript(manySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB)
 	accepted()
 
 	// Create block with the max allowed signature operations such that all
@@ -1952,11 +1954,11 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	// be rejected if any of them were counted.
 	//
 	//   ... -> b72(21) -> b73(22)
-	scriptSize = maxBlockSigOps + 5 + (maxScriptElementSize + 1)
+	scriptSize = maxBlockSigOpsPerMB + 5 + (maxScriptElementSize + 1)
 	manySigOps = repeatOpcode(txscript.OP_CHECKSIG, scriptSize)
-	manySigOps[maxBlockSigOps] = txscript.OP_PUSHDATA4
+	manySigOps[maxBlockSigOpsPerMB] = txscript.OP_PUSHDATA4
 	g.nextBlock("b73", outs[22], replaceSpendScript(manySigOps))
-	g.assertTipBlockSigOpsCount(maxBlockSigOps)
+	g.assertTipBlockSigOpsCount(maxBlockSigOpsPerMB)
 	accepted()
 
 	// ---------------------------------------------------------------------

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -1236,7 +1236,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//
 	// OP_CHECKMULTISIG counts for 20 sigops.
 	tooManySigOps = repeatOpcode(txscript.OP_CHECKMULTISIG, maxBlockSigOps/20)
-	tooManySigOps = append(manySigOps, txscript.OP_CHECKSIG)
+	tooManySigOps = append(tooManySigOps, txscript.OP_CHECKSIG)
 	g.nextBlock("b32", outs[9], replaceSpendScript(tooManySigOps))
 	g.assertTipBlockSigOpsCount(maxBlockSigOps + 1)
 	rejected(blockchain.ErrTxTooManySigOps)

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -95,9 +95,6 @@ func (b *BlockChain) MaxBlockSize(uahfActive bool) int {
 // operations in a block. The value is a function of the serialized
 // block size in bytes.
 func MaxBlockSigOps(nBlockBytes uint32) int {
-
-	// todo: is nBlockMBytesRoundedUp based on total block with transactions
-
 	nBlockMBytesRoundedUp := 1 + ((int(nBlockBytes) - 1) / oneMegabyte)
 	return nBlockMBytesRoundedUp * MaxBlockSigOpsPerMB
 }

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1062,8 +1062,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *bchutil.Block, vi
 	}
 
 	// If Uahf is active then we need to calculate the max block size
-	// and max sigops using the excessiveBlockSize rather than the
-	// LegacyBlockSize
+	// using the excessiveBlockSize rather than the LegacyBlockSize
 	uahfActive := node.height > b.chainParams.UahfForkHeight
 
 	// If Daa hardfork is active then we need to use the new difficulty

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1163,11 +1163,8 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *bchutil.Block, vi
 	// scripts.
 	transactions := block.Transactions()
 	totalSigOpCost := 0
-	blockBytes, err := block.Bytes()
-	if err != nil {
-		return err
-	}
-	maxSigOps := MaxBlockSigOps(uint32(len(blockBytes)))
+	nBlockBytes := block.MsgBlock().SerializeSize()
+	maxSigOps := MaxBlockSigOps(uint32(nBlockBytes))
 	for i, tx := range transactions {
 		// Since the first (and only the first) transaction has
 		// already been verified to be a coinbase transaction,

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -50,17 +50,19 @@ const (
 	LegacyMaxBlockSize = 1000000
 
 	// MaxBlockSigOpsPerMB is the maximum number of allowed sigops allowed
-	// per one megabyte allowed in a block
+	// per one (or partial) megabyte of block size after the UAHF hard fork
 	MaxBlockSigOpsPerMB = 20000
 
 	// MaxTransactionSize is the maximum allowable size of a transaction
-	MaxTransactionSize = 1000000
+	// after the UAHF hard fork
+	MaxTransactionSize = oneMegabyte
 
 	// MinTransactionSize is the minimum transaction size allowed on the
 	// network after the magneticanomaly hardfork
 	MinTransactionSize = 100
 
-	// MaxTransactionSigOps is the maximum allowable number of sigops per transaction
+	// MaxTransactionSigOps is the maximum allowable number of sigops per
+	// transaction after the UAHF hard fork
 	MaxTransactionSigOps = 20000
 )
 

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -366,10 +366,10 @@ func newTestBlock(base, tip *wire.MsgBlock, coinbaseSigOps, tx1SigOps, tx2SigOps
 	prevHash := tip.Header.BlockHash()
 	prevMRoot := tip.Header.MerkleRoot
 	easyBits := chaincfg.RegressionNetParams.PowLimitBits
-	addSigOps := map[int]int {
-		0: coinbaseSigOps-1,
-		1: tx1SigOps-1,
-		2: tx2SigOps-1,
+	addSigOps := map[int]int{
+		0: coinbaseSigOps - 1,
+		1: tx1SigOps - 1,
+		2: tx2SigOps - 1,
 	}
 
 	// make a new valid block with duplicate transactions of the base block

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -336,7 +336,7 @@ func TestSigOpsLimitsWithMultiMBBlocks(t *testing.T) {
 	// coinbase: 20k + 1 sigOps (fail)   <=1MB (ok)
 	// tx1:            1 sigOps (ok)     <=1MB (ok)
 	// tx2:            1 sigOps (ok)     <=1MB (ok)
-	// block:    40k + 3 sigOps (ok)     > 1MB (ok)
+	// block:    20k + 3 sigOps (ok)     > 1MB (ok)
 	overTxLimit, err := newTestBlock(baseBlock, tip, 20001, 1, 1)
 	if err != nil {
 		t.Fatalf("Unexpected error creating sigOps test block: %v", err)
@@ -382,13 +382,13 @@ func TestSigOpsLimitsWithMultiMBBlocks(t *testing.T) {
 	isExpectedErr = false
 	if err != nil {
 		if rule, ok := err.(RuleError); ok {
-			if rule.ErrorCode == ErrTxTooManySigOps {
+			if rule.ErrorCode == ErrTooManySigOps {
 				isExpectedErr = true
 			}
 		}
 	}
 	if !isExpectedErr {
-		t.Fatalf("Expected to fail with TxTooManySigOps but got: %v", err)
+		t.Fatalf("Expected to fail with TooManySigOps but got: %v", err)
 	}
 }
 

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -7,6 +7,7 @@ package blockchain
 import (
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -243,14 +244,6 @@ func TestSigOpsLimitsWithMultiMBBlocks(t *testing.T) {
 	}
 	defer teardownFunc()
 
-	// Since we're not dealing with the real block chain, set the coinbase
-	// maturity to 1.
-	chain.TstSetCoinbaseMaturity(1)
-
-	chain.chainParams.UahfForkHeight = 2
-	chain.chainParams.ReduceMinDifficulty = true
-	chain.chainParams.MinDiffReductionTime = time.Second
-
 	// Load blocks #1 and #2 with transactions,
 	// then 144 empty blocks to make room for UAHF difficulty adjustment window,
 	// for a total of genesis + 146 blocks.
@@ -259,114 +252,162 @@ func TestSigOpsLimitsWithMultiMBBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error loading file: %v\n", err)
 	}
-	easiestBits := chain.chainParams.PowLimitBits
 	blocks := make([]*wire.MsgBlock, 146)
 	blocks[0] = contentBlocks[1].MsgBlock()
 	blocks[1] = contentBlocks[2].MsgBlock()
+	tip := blocks[1]
+	baseBlock := blocks[1]
 	for i := 2; i < 146; i++ {
-		prevHash := blocks[i-1].BlockHash()
-		prevMRoot := blocks[i-1].Header.MerkleRoot
-		blocks[i] = wire.NewMsgBlock(wire.NewBlockHeader(
-			1, &prevHash, &prevMRoot, easiestBits, 2))
-		err := blocks[i].AddTransaction(blocks[i-1].Transactions[0].Copy())
+		blocks[i], err = newTestBlock(baseBlock, tip, 1, 1, 1)
 		if err != nil {
 			t.Fatalf("Unexpected error building difficulty adjustment "+
 				"window block %d: %v", i, err)
 		}
-		setValidMerkleRoot(blocks[i])
-		solveBlock(&blocks[i].Header)
-	}
-	// add all the blocks to the blockchain leading up to the test block
-	for i, wireBlock := range blocks {
-		b := bchutil.NewBlock(wireBlock)
-		b.SetHeight(int32(i) + 1)
-		_, _, err := chain.ProcessBlock(b, BFNone)
-		if err != nil {
-			t.Fatalf("TestSigOpsLimitsWithMultiMBBlocks: Received unexpected error "+
-				"processing block %d: %v", i+1, err)
-		}
+		tip = blocks[i]
 	}
 
-	// Setup block 3 to test sigOps limits
-	// Summary of block 3 from file:
-	// coinbase: 1 sigOp     <=1MB
-	// tx1:      1 sigOp     <=1MB
-	// tx2:      1 sigOp     <=1MB
-	// block:    3 sigOps    < 1MB
-	sigOpsBlock := contentBlocks[3].MsgBlock()
-	sigOpsBlock.Header.Timestamp = blocks[145].Header.Timestamp.Add(time.Second)
-	sigOpsBlock.Header.PrevBlock = blocks[145].Header.BlockHash()
-
-	// Add 20k sigOps to the coinbase to break the sigOps per-tx limit
-	// and
-	// Add just enough NOOPs to the coinbase to
-	// ensure that we are not breaking tx size limits and
-	// ensure that we are validating with >1MB block rules:
-	// coinbase: 20k + 1 sigOps (fail)   <=1MB (ok)
-	// tx1:            1 sigOp  (ok)     <=1MB (ok)
-	// tx2:            1 sigOp  (ok)     <=1MB (ok)
-	// block:    20k + 3 sigOps (ok)     > 1MB (ok)
-
-	coinbaseOut := sigOpsBlock.Transactions[0].TxOut[0]
-	coinbaseOut.PkScript = append(coinbaseOut.PkScript,
-		repeatScript(979338, txscript.OP_NOP)...)
-	coinbaseOut.PkScript = append(coinbaseOut.PkScript,
-		repeatScript(20000, txscript.OP_CHECKSIG)...)
-
-	validateBigBlock := func(mb *wire.MsgBlock, expectSuccess bool) {
-		setValidMerkleRoot(mb)
-		mb.Header.Bits = easiestBits
-		solveBlock(&mb.Header)
+	// Tests start here.
+	// We ensure blocks >1MB and then pass or break exactly one consensus limit at a time
+	validateBigBlock := func(mb *wire.MsgBlock) error {
 		var txSize, blockSize int
+
+		// Confirm that we never fail due to breaking tx size.
 		for i, tx := range mb.Transactions {
 			txSize = tx.SerializeSize()
 			if txSize > oneMegabyte {
 				t.Fatalf("expected tx %d to be <1MB but got %d bytes", i, txSize)
 			}
 		}
-		blockSize = mb.SerializeSize()
-		if blockSize <= oneMegabyte {
-			t.Fatalf("expected block to be >1MB but got %d bytes", blockSize)
-		}
-		b := bchutil.NewBlock(mb)
-		b.SetHeight(147)
-		// TODO: I could not find any way to build on the main chain without incurring
-		//       heavy solve costs. Using regressionnet means this becomes just an extension
-		//       of fullblocktests (which should be done also)
-		_, _, err = chain.ProcessBlock(b, BFNone)
-		//err = chain.CheckConnectBlockTemplate(b)
-		if !expectSuccess && (err == nil) {
-			t.Fatal("TestSigOpsLimitsWithMultiMBBlocks: Expected to fail validation " +
-				" but got no error")
-		} else if expectSuccess && (err != nil) {
-			t.Fatalf("TestSigOpsLimitsWithMultiMBBlocks: Expected to validate "+
-				" but got: %v", err)
-		}
-	}
-	validateBigBlock(sigOpsBlock, false)
 
-	// Set coinbase to exactly 20000 so we are not failing due to the coinbase transaction
-	// and
-	// Add to 19,999 sigOps to transaction 1:
+		// Confirm that the block is always in the interval (1MB, 2MB] so we are testing big block rules
+		blockSize = mb.SerializeSize()
+		if (blockSize <= oneMegabyte) || (blockSize > 2*oneMegabyte) {
+			t.Fatalf("expected block to be in the interval  (1MB, 2MB] but got %d bytes", blockSize)
+		}
+
+		b := bchutil.NewBlock(mb)
+		_, _, err = chain.ProcessBlock(b, BFNone)
+		return err
+	}
+
+	// Use the original block 3 content to test sigOps limits
+	// Summary of block 3 from file:
+	// coinbase: 1 sigOps    <=1MB
+	// tx1:      1 sigOps    <=1MB
+	// tx2:      1 sigOps    <=1MB
+	// block:    3 sigOps    < 1MB
+	baseBlock = contentBlocks[3].MsgBlock()
+	// Add 3 * 400k NOOPs to get >1MB block without breaking Tx size limits
+	manyNoOps := repeatScript(400000, txscript.OP_NOP)
+	for _, tx := range baseBlock.Transactions {
+		tx.TxOut[0].PkScript = append(tx.TxOut[0].PkScript, manyNoOps...)
+	}
+
+	// 1. Pass at per-Tx sigOps limit
+	// coinbase:     20k sigOps (ok)     <=1MB (ok)
+	// tx1:            1 sigOps (ok)     <=1MB (ok)
+	// tx2:            1 sigOps (ok)     <=1MB (ok)
+	// block:    20k + 2 sigOps (ok)     > 1MB (ok)
+	atTxLimit, err := newTestBlock(baseBlock, tip, 20000, 1, 1)
+	if err != nil {
+		t.Fatalf("Unexpected error creating sigOps test block: %v", err)
+	}
+	err = validateBigBlock(atTxLimit)
+	if err != nil {
+		t.Fatalf("Expected to validate but got: %v", err)
+	}
+	tip = atTxLimit
+
+	// 1. Fail at per-Tx sigOps limit +1
+	// coinbase: 20k + 1 sigOps (fail)   <=1MB (ok)
+	// tx1:            1 sigOps (ok)     <=1MB (ok)
+	// tx2:            1 sigOps (ok)     <=1MB (ok)
+	// block:    20k + 3 sigOps (ok)     > 1MB (ok)
+	overTxLimit, err := newTestBlock(baseBlock, tip, 20001, 1, 1)
+	if err != nil {
+		t.Fatalf("Unexpected error creating sigOps test block: %v", err)
+	}
+	err = validateBigBlock(overTxLimit)
+	if (err == nil) || !strings.Contains(err.Error(), "too many sigops") {
+		t.Fatalf("Expected to fail with sigops error but got %v", err)
+	}
+
+	// 2. Pass at per-block sigOps limit
+	// coinbase:     20k sigOps (ok)     <=1MB (ok)
+	// tx1:        19999 sigOps (ok)     <=1MB (ok)
+	// tx2:            1 sigOp  (ok)     <=1MB (ok)
+	// block:        40k sigOps (ok)     > 1MB (ok)
+	atBlockLimit, err := newTestBlock(baseBlock, tip, 20000, 19999, 1)
+	if err != nil {
+		t.Fatalf("Unexpected error creating sigOps test block: %v", err)
+	}
+	err = validateBigBlock(atBlockLimit)
+	if err != nil {
+		t.Fatalf("Expected to validate but got: %v", err)
+	}
+	tip = atTxLimit
+
+	// 2. Fail at per-block sigOps limit +1
 	// coinbase:     20k sigOps (ok)     <=1MB (ok)
 	// tx1:          20k sigOps (ok)     <=1MB (ok)
 	// tx2:            1 sigOp  (ok)     <=1MB (ok)
 	// block:    40k + 1 sigOps (fail)   > 1MB (ok)
-	coinbaseOut.PkScript = coinbaseOut.PkScript[:len(coinbaseOut.PkScript)-1]
-	tx1Out := sigOpsBlock.Transactions[1].TxOut[0]
-	tx1Out.PkScript = append(tx1Out.PkScript,
-		repeatScript(20000, txscript.OP_CHECKSIGVERIFY)...)
-	validateBigBlock(sigOpsBlock, false)
-
-	// Finally set tx1 to 19,999 sigOps so that we should validate at the limit
-	// of both transaction and block sigOps:
-	// coinbase:    20k sigOps (ok)     <=1MB (ok)
-	// tx1:      19,999 sigOps (ok)     <=1MB (ok)
-	// tx2:           1 sigOp  (ok)     <=1MB (ok)
-	// block:       40k sigOps (ok)     > 1MB (ok)
-	tx1Out.PkScript = tx1Out.PkScript[:len(tx1Out.PkScript)-1]
-	validateBigBlock(sigOpsBlock, true)
+	overBlockLimit, err := newTestBlock(baseBlock, tip, 20000, 20000, 1)
+	if err != nil {
+		t.Fatalf("Unexpected error creating sigOps test block: %v", err)
+	}
+	err = validateBigBlock(overBlockLimit)
+	if (err == nil) || !strings.Contains(err.Error(), "asdf") {
+		t.Fatalf("Expected to fail with sigops error but got %v", err)
+	}
 }
+
+func newTestBlock(base, tip *wire.MsgBlock, coinbaseSigOps, tx1SigOps, tx2SigOps int) (*wire.MsgBlock, error) {
+	prevHash := tip.Header.BlockHash()
+	prevMRoot := tip.Header.MerkleRoot
+	easyBits := chaincfg.RegressionNetParams.PowLimitBits
+	addSigOps := map[int]int {
+		0: coinbaseSigOps-1,
+		1: tx1SigOps-1,
+		2: tx2SigOps-1,
+	}
+
+	// make a new valid block with duplicate transactions of the base block
+	dup := wire.NewMsgBlock(wire.NewBlockHeader(
+		1, &prevHash, &prevMRoot, easyBits, 2))
+	dup.Header.Timestamp = tip.Header.Timestamp.Add(time.Second)
+	for i, tx := range base.Transactions {
+		err := dup.AddTransaction(tx.Copy())
+		if err != nil {
+			return nil, err
+		}
+		// also add the target number of sigOps
+		dupTxOut := dup.Transactions[i].TxOut[0]
+		dupTxOut.PkScript = append(dupTxOut.PkScript,
+			repeatScript(addSigOps[i], txscript.OP_CHECKSIG)...)
+	}
+
+	setValidMerkleRoot(dup)
+	solveBlock(&dup.Header)
+	return dup, nil
+}
+
+//func cloneBlock(b *wire.MsgBlock, easiestBits uint32) (*wire.MsgBlock, error) {
+//	prevHash := b.BlockHash()
+//	prevMRoot := b.Header.MerkleRoot
+//	dup := wire.NewMsgBlock(wire.NewBlockHeader(
+//		1, &prevHash, &prevMRoot, easiestBits, 2))
+//	for _, tx := range b.Transactions {
+//		err := dup.AddTransaction(tx.Copy())
+//		if err != nil {
+//			return nil, err
+//		}
+//	}
+//	setValidMerkleRoot(dup)
+//	solveBlock(&dup.Header)
+//
+//	return dup, nil
+//}
 
 // calcMerkleRoot recalculates the merkle root.
 func setValidMerkleRoot(b *wire.MsgBlock) {

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -422,23 +422,6 @@ func newTestBlock(base, tip *wire.MsgBlock, coinbaseSigOps, tx1SigOps, tx2SigOps
 	return dup, nil
 }
 
-//func cloneBlock(b *wire.MsgBlock, easiestBits uint32) (*wire.MsgBlock, error) {
-//	prevHash := b.BlockHash()
-//	prevMRoot := b.Header.MerkleRoot
-//	dup := wire.NewMsgBlock(wire.NewBlockHeader(
-//		1, &prevHash, &prevMRoot, easiestBits, 2))
-//	for _, tx := range b.Transactions {
-//		err := dup.AddTransaction(tx.Copy())
-//		if err != nil {
-//			return nil, err
-//		}
-//	}
-//	setValidMerkleRoot(dup)
-//	solveBlock(&dup.Header)
-//
-//	return dup, nil
-//}
-
 // calcMerkleRoot recalculates the merkle root.
 func setValidMerkleRoot(b *wire.MsgBlock) {
 	if len(b.Transactions) == 0 {

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -110,6 +110,42 @@ func TestCountSigOps(t *testing.T) {
 	}
 }
 
+// TestMaxBlockSigOps confirms max sig ops rules:
+// 1) 20000 * integer block size in megabytes
+// 2) integer block size is rounded up when not perfectly divisible
+func TestMaxBlockSigOps(t *testing.T) {
+	testCases := []struct {
+		name              string
+		nBlockBytes       uint32
+		expectedMaxSigOps int
+	}{
+		{
+			"exactly 1 MB should be 1*opsPerMB",
+			oneMegabyte,
+			20000 * 1,
+		}, {
+			"over 1 MB should be rounded to 2*opsPerMB",
+			oneMegabyte + 1,
+			20000 * 2,
+		}, {
+			"under 1 MB should be rounded to 1*opsPerMB",
+			oneMegabyte - 1,
+			20000 * 1,
+		}, {
+			"exactly 31 MB should be 31*opsPerMB",
+			31 * oneMegabyte,
+			20000 * 31,
+		},
+	}
+	for _, tc := range testCases {
+		result := MaxBlockSigOps(tc.nBlockBytes)
+		if result != tc.expectedMaxSigOps {
+			t.Fatalf("%s: expected MaxBlockSigOps %d but got %d",
+				tc.name, tc.expectedMaxSigOps, result)
+		}
+	}
+}
+
 // TestCheckConnectBlockTemplate tests the CheckConnectBlockTemplate function to
 // ensure it fails.
 func TestCheckConnectBlockTemplate(t *testing.T) {

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -7,7 +7,6 @@ package blockchain
 import (
 	"math"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -328,8 +327,16 @@ func TestSigOpsLimitsWithMultiMBBlocks(t *testing.T) {
 		t.Fatalf("Unexpected error creating sigOps test block: %v", err)
 	}
 	err = validateBigBlock(overTxLimit)
-	if (err == nil) || !strings.Contains(err.Error(), "too many sigops") {
-		t.Fatalf("Expected to fail with sigops error but got %v", err)
+	isExpectedErr := false
+	if err != nil {
+		if rule, ok := err.(RuleError); ok {
+			if rule.ErrorCode == ErrTxTooManySigOps {
+				isExpectedErr = true
+			}
+		}
+	}
+	if !isExpectedErr {
+		t.Fatalf("Expected to fail with TooManySigOps but got: %v", err)
 	}
 
 	// 2. Pass at per-block sigOps limit
@@ -357,8 +364,16 @@ func TestSigOpsLimitsWithMultiMBBlocks(t *testing.T) {
 		t.Fatalf("Unexpected error creating sigOps test block: %v", err)
 	}
 	err = validateBigBlock(overBlockLimit)
-	if (err == nil) || !strings.Contains(err.Error(), "asdf") {
-		t.Fatalf("Expected to fail with sigops error but got %v", err)
+	isExpectedErr = false
+	if err != nil {
+		if rule, ok := err.(RuleError); ok {
+			if rule.ErrorCode == ErrTooManySigOps {
+				isExpectedErr = true
+			}
+		}
+	}
+	if !isExpectedErr {
+		t.Fatalf("Expected to fail with TooManySigOps but got: %v", err)
 	}
 }
 

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -454,7 +454,6 @@ func (g *BlkTmplGenerator) NewBlockTemplate(payToAddress bchutil.Address) (*Bloc
 	uahfActive := nextBlockHeight >= g.chainParams.UahfForkHeight
 
 	maxBlockSize := g.chain.MaxBlockSize(uahfActive)
-	maxSigOps := g.chain.MaxBlockSigOps(uahfActive)
 
 	// Create a standard coinbase transaction paying to the provided
 	// address.  NOTE: The coinbase value will be updated to include the
@@ -624,6 +623,7 @@ mempoolLoop:
 	blockSize := uint32(blockHeaderOverhead * coinbaseTx.MsgTx().SerializeSize())
 	blockSigOps := coinbaseSigOps
 	totalFees := int64(0)
+	maxSigOps := blockchain.MaxBlockSigOps(blockSize)
 
 	// Choose which transactions make it into the block.
 	for priorityQueue.Len() > 0 {
@@ -651,6 +651,7 @@ mempoolLoop:
 		// check for overflow.
 		sigOps, err := blockchain.GetSigOps(tx, false,
 			blockUtxos, scriptFlags)
+		maxSigOps = blockchain.MaxBlockSigOps(blockPlusTxSize)
 		if err != nil {
 			log.Tracef("Skipping tx %s due to error in "+
 				"GetSigOpCost: %v", tx.Hash(), err)

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -740,7 +740,7 @@ mempoolLoop:
 		// save the fees and signature operation counts to the block
 		// template.
 		blockTxns = append(blockTxns, tx)
-		blockSize += txSize
+		blockSize = blockPlusTxSize
 		blockSigOps += int64(sigOps)
 		totalFees += prioItem.fee
 		txFees = append(txFees, prioItem.fee)


### PR DESCRIPTION
Fixes #178 

Relevant code for comparison in ABC: [In consensus.h](https://github.com/Bitcoin-ABC/bitcoin-abc/blob/d1d091ba73f574ae5eb189fe7655c67bf5d338cf/src/consensus/consensus.h#L53)

```c++
/**
 * Compute the maximum number of sigops operation that can contained in a block
 * given the block size as parameter. It is computed by multiplying
 * MAX_BLOCK_SIGOPS_PER_MB by the size of the block in MB rounded up to the
 * closest integer.
 */
inline uint64_t GetMaxBlockSigOpsCount(uint64_t blockSize) {
    auto nMbRoundedUp = 1 + ((blockSize - 1) / ONE_MEGABYTE);
    return nMbRoundedUp * MAX_BLOCK_SIGOPS_PER_MB;
}
```