### PR TITLE
Fix bugs in UTXO rollback

### DIFF
--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -708,13 +708,11 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, fastSync bool, interrupt
 	var statusNodeNext *blockNode // the first one higher than the statusNode
 	attachNodes := list.New()
 	for node := tip; node.height >= 0; node = node.parent {
-		attachNodes.PushFront(node)
-
 		if node.hash == *statusHash {
 			statusNode = node
 			break
 		}
-
+		attachNodes.PushFront(node)
 		statusNodeNext = node
 	}
 
@@ -785,7 +783,7 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, fastSync bool, interrupt
 	}
 
 	log.Debugf("Replaying %d blocks to rebuild UTXO state...",
-		tip.height-statusNodeNext.height)
+		tip.height-statusNodeNext.height+1)
 
 	// Then we replay the blocks from the last consistent state up to the best
 	// state. Iterate forward from the consistent node to the tip of the best
@@ -833,6 +831,9 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, fastSync bool, interrupt
 			log.Warn("UTXO state reconstruction interrupted")
 
 			return errInterruptRequested
+		}
+		if node.height == tip.height {
+			break
 		}
 	}
 


### PR DESCRIPTION
This fixes a couple bugs in the UTXO set reconstruction code. Specifically the
roll forward starts one block too early resulting in a UTXO missing error.

Also it was missing a break from the final rollforward loop which caused it
to remain stuck forever.