### PR TITLE
Add GetCFMempool functionality

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -127,6 +127,9 @@ type MessageListeners struct {
 	// message.
 	OnCFCheckpt func(p *Peer, msg *wire.MsgCFCheckpt)
 
+	// OnCFMempool is invoked when a peer receives a cfmempool bitcoin message.
+	OnCFMempool func(p *Peer, msg *wire.MsgCFMempool)
+
 	// OnInv is invoked when a peer receives an inv bitcoin message.
 	OnInv func(p *Peer, msg *wire.MsgInv)
 
@@ -159,6 +162,10 @@ type MessageListeners struct {
 	// OnGetCFCheckpt is invoked when a peer receives a getcfcheckpt
 	// bitcoin message.
 	OnGetCFCheckpt func(p *Peer, msg *wire.MsgGetCFCheckpt)
+
+	// OnGetCFMempool is invoked when a peer receives a getcfmempool
+	// bitcoin message.
+	OnGetCFMempool func(p *Peer, msg *wire.MsgGetCFMempool)
 
 	// OnFeeFilter is invoked when a peer receives a feefilter bitcoin message.
 	OnFeeFilter func(p *Peer, msg *wire.MsgFeeFilter)
@@ -1487,6 +1494,11 @@ out:
 				p.cfg.Listeners.OnGetCFCheckpt(p, msg)
 			}
 
+		case *wire.MsgGetCFMempool:
+			if p.cfg.Listeners.OnGetCFMempool != nil {
+				p.cfg.Listeners.OnGetCFMempool(p, msg)
+			}
+
 		case *wire.MsgCFilter:
 			if p.cfg.Listeners.OnCFilter != nil {
 				p.cfg.Listeners.OnCFilter(p, msg)
@@ -1495,6 +1507,11 @@ out:
 		case *wire.MsgCFHeaders:
 			if p.cfg.Listeners.OnCFHeaders != nil {
 				p.cfg.Listeners.OnCFHeaders(p, msg)
+			}
+
+		case *wire.MsgCFMempool:
+			if p.cfg.Listeners.OnCFMempool != nil {
+				p.cfg.Listeners.OnCFMempool(p, msg)
 			}
 
 		case *wire.MsgFeeFilter:

--- a/wire/message.go
+++ b/wire/message.go
@@ -64,9 +64,11 @@ const (
 	CmdGetCFilters  = "getcfilters"
 	CmdGetCFHeaders = "getcfheaders"
 	CmdGetCFCheckpt = "getcfcheckpt"
+	CmdGetCFMempool = "getcfmempool"
 	CmdCFilter      = "cfilter"
 	CmdCFHeaders    = "cfheaders"
 	CmdCFCheckpt    = "cfcheckpt"
+	CmdCFMempool    = "cfmempool"
 )
 
 // MessageEncoding represents the wire message encoding format to be used.
@@ -181,6 +183,12 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdCFCheckpt:
 		msg = &MsgCFCheckpt{}
+
+	case CmdCFMempool:
+		msg = &MsgCFMempool{}
+
+	case CmdGetCFMempool:
+		msg = &MsgGetCFMempool{}
 
 	default:
 		return nil, fmt.Errorf("unhandled command [%s]", command)

--- a/wire/msgcfmempool.go
+++ b/wire/msgcfmempool.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/gcash/bchd/chaincfg/chainhash"
+)
+
+// MsgCFMempool implements the Message interface and represents a bitcoin cfmempool
+// message. It is used to deliver a committed filter in response to a
+// getcfmempool (MsgGetCFMempool) message.
+type MsgCFMempool struct {
+	FilterType FilterType
+	Data       []byte
+}
+
+// BchDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgCFMempool) BchDecode(r io.Reader, pver uint32, _ MessageEncoding) error {
+	// Read filter type
+	err := readElement(r, &msg.FilterType)
+	if err != nil {
+		return err
+	}
+
+	// Read filter data
+	msg.Data, err = ReadVarBytes(r, pver, MaxCFilterDataSize,
+		"cfmempool data")
+	return err
+}
+
+// BchEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgCFMempool) BchEncode(w io.Writer, pver uint32, _ MessageEncoding) error {
+	size := len(msg.Data)
+	if size > MaxCFilterDataSize {
+		str := fmt.Sprintf("cfmempool size too large for message "+
+			"[size %v, max %v]", size, MaxCFilterDataSize)
+		return messageError("MsgCFMempool.BchEncode", str)
+	}
+
+	err := writeElement(w, msg.FilterType)
+	if err != nil {
+		return err
+	}
+
+	return WriteVarBytes(w, pver, msg.Data)
+}
+
+// Deserialize decodes a filter from r into the receiver using a format that is
+// suitable for long-term storage such as a database. This function differs
+// from BchDecode in that BchDecode decodes from the bitcoin wire protocol as
+// it was sent across the network.  The wire encoding can technically differ
+// depending on the protocol version and doesn't even really need to match the
+// format of a stored filter at all. As of the time this comment was written,
+// the encoded filter is the same in both instances, but there is a distinct
+// difference and separating the two allows the API to be flexible enough to
+// deal with changes.
+func (msg *MsgCFMempool) Deserialize(r io.Reader) error {
+	// At the current time, there is no difference between the wire encoding
+	// and the stable long-term storage format.  As a result, make use of
+	// BchDecode.
+	return msg.BchDecode(r, 0, BaseEncoding)
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgCFMempool) Command() string {
+	return CmdCFMempool
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgCFMempool) MaxPayloadLength(pver uint32) uint32 {
+	return uint32(VarIntSerializeSize(MaxCFilterDataSize)) +
+		MaxCFilterDataSize + chainhash.HashSize + 1
+}
+
+// NewMsgCFMempool returns a new bitcoin cfmempool message that conforms to the
+// Message interface. See MsgCFMempool for details.
+func NewMsgCFMempool(filterType FilterType, data []byte) *MsgCFilter {
+	return &MsgCFilter{
+		FilterType: filterType,
+		Data:       data,
+	}
+}

--- a/wire/msggetcfmempool.go
+++ b/wire/msggetcfmempool.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"io"
+)
+
+// MsgGetCFMempool is a request for a filter of the remote peer's mempool.
+type MsgGetCFMempool struct{}
+
+// BchDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgGetCFMempool) BchDecode(r io.Reader, pver uint32, _ MessageEncoding) error {
+	return nil
+}
+
+// BchEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgGetCFMempool) BchEncode(w io.Writer, pver uint32, _ MessageEncoding) error {
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgGetCFMempool) Command() string {
+	return CmdGetCFMempool
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgGetCFMempool) MaxPayloadLength(pver uint32) uint32 {
+	return 0
+}
+
+// NewMsgGetCFMempool returns a new bitcoin getcfmempool message that conforms
+// to the Message interface using the passed parameters and defaults for the
+// remaining fields.
+func NewMsgGetCFMempool() *MsgGetCFMempool {
+	return &MsgGetCFMempool{}
+}


### PR DESCRIPTION
Get a filter of the remote peer's mempool. Can be used by lite client to decide whether to download the mempool at startup. 