### PR TITLE
Fix OnGetCFMempool function

### DIFF
--- a/server.go
+++ b/server.go
@@ -611,9 +611,9 @@ func (sp *serverPeer) OnMemPool(_ *peer.Peer, msg *wire.MsgMemPool) {
 // It creates a Cfilter of node's mempool and sends it to the requesting peer in a
 // cfilter message.
 func (sp *serverPeer) OnGetCFMemPool(_ *peer.Peer, msg *wire.MsgGetCFMempool) {
-	// Only allow cfmempool requests if the server has nodeCF enabled
+	// Only allow getcfmempool requests if the server has nodeCF enabled
 	if sp.server.services&wire.SFNodeCF != wire.SFNodeCF {
-		peerLog.Debugf("peer %v sent cfmempool request with NodeCF "+
+		peerLog.Debugf("peer %v sent getcfmempool request with NodeCF "+
 			"disabled -- disconnecting", sp)
 		sp.Disconnect()
 		return
@@ -624,6 +624,16 @@ func (sp *serverPeer) OnGetCFMemPool(_ *peer.Peer, msg *wire.MsgGetCFMempool) {
 	// getcfmempool messages comes from a peer. The score decays each minute to
 	// half of its value.
 	sp.addBanScore(0, 33, "getcfmempool")
+
+	switch msg.FilterType {
+	case wire.GCSFilterRegular:
+		break
+
+	default:
+		peerLog.Debugf("Mempool filter request for unknown filter: %v",
+			msg.FilterType)
+		return
+	}
 
 	txs, scripts, err := sp.server.txMemPool.TxsAndPrevOutScripts()
 	if err != nil {
@@ -1085,7 +1095,7 @@ func (sp *serverPeer) OnGetCFilters(_ *peer.Peer, msg *wire.MsgGetCFilters) {
 		break
 
 	default:
-		peerLog.Debug("Filter request for unknown filter: %v",
+		peerLog.Debugf("Filter request for unknown filter: %v",
 			msg.FilterType)
 		return
 	}
@@ -1141,7 +1151,7 @@ func (sp *serverPeer) OnGetCFHeaders(_ *peer.Peer, msg *wire.MsgGetCFHeaders) {
 		break
 
 	default:
-		peerLog.Debug("Filter request for unknown headers for "+
+		peerLog.Debugf("Filter request for unknown headers for "+
 			"filter: %v", msg.FilterType)
 		return
 	}
@@ -1258,7 +1268,7 @@ func (sp *serverPeer) OnGetCFCheckpt(_ *peer.Peer, msg *wire.MsgGetCFCheckpt) {
 		break
 
 	default:
-		peerLog.Debug("Filter request for unknown checkpoints for "+
+		peerLog.Debugf("Filter request for unknown checkpoints for "+
 			"filter: %v", msg.FilterType)
 		return
 	}

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -112,8 +112,10 @@ func ExtractDataElements(script []byte) ([][]byte, error) {
 		return nil, err
 	}
 	for _, pop := range pops {
-		// All opcodes up to OP_16 are data push instructions.
-		if pop.opcode.value <= OP_16 {
+		// The only opcodes which carry data are OP_DATA_1 to OP_PUSHDATA4.
+		// OP_0 and OP_1 - OP_16 are ignored for the purpose of this function
+		// even though they push data to the stack.
+		if pop.opcode.value > OP_0 && pop.opcode.value <= OP_PUSHDATA4 {
 			dataElements = append(dataElements, pop.data)
 		}
 	}

--- a/wire/msggetcfmempool.go
+++ b/wire/msggetcfmempool.go
@@ -9,18 +9,20 @@ import (
 )
 
 // MsgGetCFMempool is a request for a filter of the remote peer's mempool.
-type MsgGetCFMempool struct{}
+type MsgGetCFMempool struct {
+	FilterType FilterType
+}
 
 // BchDecode decodes r using the bitcoin protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgGetCFMempool) BchDecode(r io.Reader, pver uint32, _ MessageEncoding) error {
-	return nil
+	return readElement(r, &msg.FilterType)
 }
 
 // BchEncode encodes the receiver to w using the bitcoin protocol encoding.
 // This is part of the Message interface implementation.
 func (msg *MsgGetCFMempool) BchEncode(w io.Writer, pver uint32, _ MessageEncoding) error {
-	return nil
+	return writeElement(w, msg.FilterType)
 }
 
 // Command returns the protocol command string for the message.  This is part
@@ -32,12 +34,11 @@ func (msg *MsgGetCFMempool) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetCFMempool) MaxPayloadLength(pver uint32) uint32 {
-	return 0
+	return 1
 }
 
 // NewMsgGetCFMempool returns a new bitcoin getcfmempool message that conforms
-// to the Message interface using the passed parameters and defaults for the
-// remaining fields.
-func NewMsgGetCFMempool() *MsgGetCFMempool {
-	return &MsgGetCFMempool{}
+// to the Message interface using the passed parameters.
+func NewMsgGetCFMempool(filterType FilterType) *MsgGetCFMempool {
+	return &MsgGetCFMempool{FilterType: filterType}
 }


### PR DESCRIPTION
The `GetCFMemPool` function actually had incorrect behavior. It's supposed to return the prevout script for each returned tx but it was only checking the utxo cache for prevout scripts meaning it might omit prevout scripts from mempool transactions spending from other transactions in the mempool. 

Also add a filter type to the getcfmempool request.

This PR fixes this along with some comments in the function. 