### PR TITLE
[Feature] Add stub for xversion messages

### DIFF
--- a/server.go
+++ b/server.go
@@ -12,7 +12,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/gcash/bchutil/gcs/builder"
 	"math"
 	"net"
 	"runtime"
@@ -22,6 +21,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/gcash/bchutil/gcs/builder"
 
 	"github.com/gcash/bchd/addrmgr"
 	"github.com/gcash/bchd/blockchain"
@@ -557,6 +558,11 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 		sp.Peer.QueueMessage(sendCmpctMessage, nil)
 	}
 	return nil
+}
+
+// OnXVersion is invoked when a peer receives an xversion message.
+func (sp *serverPeer) OnXVersion(_ *peer.Peer, msg *wire.MsgXVersion) {
+	sp.Peer.QueueMessage(wire.NewMsgXVerAck(), nil)
 }
 
 // OnMemPool is invoked when a peer receives a mempool bitcoin message.
@@ -2418,6 +2424,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 	return &peer.Config{
 		Listeners: peer.MessageListeners{
 			OnVersion:      sp.OnVersion,
+			OnXVersion:     sp.OnXVersion,
 			OnMemPool:      sp.OnMemPool,
 			OnTx:           sp.OnTx,
 			OnBlock:        sp.OnBlock,

--- a/wire/message.go
+++ b/wire/message.go
@@ -40,7 +40,9 @@ func maxMessagePayload() uint32 {
 // Commands used in bitcoin message headers which describe the type of message.
 const (
 	CmdVersion      = "version"
+	CmdXVersion     = "xversion"
 	CmdVerAck       = "verack"
+	CmdXVerAck      = "xverack"
 	CmdGetAddr      = "getaddr"
 	CmdAddr         = "addr"
 	CmdGetBlocks    = "getblocks"
@@ -106,8 +108,14 @@ func makeEmptyMessage(command string) (Message, error) {
 	case CmdVersion:
 		msg = &MsgVersion{}
 
+	case CmdXVersion:
+		msg = &MsgXVersion{}
+
 	case CmdVerAck:
 		msg = &MsgVerAck{}
+
+	case CmdXVerAck:
+		msg = &MsgXVerAck{}
 
 	case CmdGetAddr:
 		msg = &MsgGetAddr{}

--- a/wire/msgxverack.go
+++ b/wire/msgxverack.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 The bchd developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"io"
+)
+
+// MsgXVerAck defines a bitcoin xverack message which is used for a peer to
+// acknowledge an xversion message (MsgXVersion).
+// It implements the Message interface.
+//
+// This message has no payload.
+type MsgXVerAck struct{}
+
+// BchDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgXVerAck) BchDecode(r io.Reader, pver uint32, enc MessageEncoding) error {
+	return nil
+}
+
+// BchEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgXVerAck) BchEncode(w io.Writer, pver uint32, enc MessageEncoding) error {
+	return nil
+}
+
+// Command returns the protocol command string for the message. This is part
+// of the Message interface implementation.
+func (msg *MsgXVerAck) Command() string {
+	return CmdXVerAck
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver. This is part of the Message interface implementation.
+func (msg *MsgXVerAck) MaxPayloadLength(pver uint32) uint32 {
+	return 0
+}
+
+// NewMsgXVerAck returns a new bitcoin verack message that conforms to the
+// Message interface.
+func NewMsgXVerAck() *MsgXVerAck {
+	return &MsgXVerAck{}
+}

--- a/wire/msgxverack_test.go
+++ b/wire/msgxverack_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2019 The bchd developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// TestVerAck tests the MsgXVerAck API.
+func TestXVerAck(t *testing.T) {
+	pver := ProtocolVersion
+
+	// Ensure the command is expected value.
+	wantCmd := "xverack"
+	msg := NewMsgXVerAck()
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("NewMsgXVerAck: wrong command - got %v want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload is expected value.
+	wantPayload := uint32(0)
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+}
+
+// TestXVerAckWire tests the MsgXVerAck wire encode and decode for various
+// protocol versions.
+func TestXVerAckWire(t *testing.T) {
+	msgXVerAck := NewMsgXVerAck()
+	msgXVerAckEncoded := []byte{}
+
+	tests := []struct {
+		in   *MsgXVerAck     // Message to encode
+		out  *MsgXVerAck     // Expected decoded message
+		buf  []byte          // Wire encoding
+		pver uint32          // Protocol version for wire encoding
+		enc  MessageEncoding // Message encoding format
+	}{
+		// Latest protocol version.
+		{
+			msgXVerAck,
+			msgXVerAck,
+			msgXVerAckEncoded,
+			ProtocolVersion,
+			BaseEncoding,
+		},
+
+		// Protocol version BIP0035Version.
+		{
+			msgXVerAck,
+			msgXVerAck,
+			msgXVerAckEncoded,
+			BIP0035Version,
+			BaseEncoding,
+		},
+
+		// Protocol version BIP0031Version.
+		{
+			msgXVerAck,
+			msgXVerAck,
+			msgXVerAckEncoded,
+			BIP0031Version,
+			BaseEncoding,
+		},
+
+		// Protocol version NetAddressTimeVersion.
+		{
+			msgXVerAck,
+			msgXVerAck,
+			msgXVerAckEncoded,
+			NetAddressTimeVersion,
+			BaseEncoding,
+		},
+
+		// Protocol version MultipleAddressVersion.
+		{
+			msgXVerAck,
+			msgXVerAck,
+			msgXVerAckEncoded,
+			MultipleAddressVersion,
+			BaseEncoding,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BchEncode(&buf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BchEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BchEncode #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg MsgXVerAck
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BchDecode(rbuf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BchDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, test.out) {
+			t.Errorf("BchDecode #%d\n got: %s want: %s", i,
+				spew.Sdump(msg), spew.Sdump(test.out))
+			continue
+		}
+	}
+}

--- a/wire/msgxversion.go
+++ b/wire/msgxversion.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2019 The bchd developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"io"
+)
+
+// MsgXVersion implements the Message interface and represents a bitcoin xversion
+// message. This is a stub used to support BU clients.
+type MsgXVersion struct {
+}
+
+// BchDecode decodes r using the bitcoin protocol encoding into the receiver.
+//
+// This is part of the Message interface implementation.
+func (msg *MsgXVersion) BchDecode(r io.Reader, pver uint32, enc MessageEncoding) error {
+	return nil
+}
+
+// BchEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgXVersion) BchEncode(w io.Writer, pver uint32, enc MessageEncoding) error {
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgXVersion) Command() string {
+	return CmdXVersion
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgXVersion) MaxPayloadLength(pver uint32) uint32 {
+	// May payload size for xversion messages is defined as
+	// 100000 in the spec.
+	return 100000
+}
+
+// NewMsgXVersion returns a new bitcoin xversion message that conforms to the
+// Message interface using the passed parameters and defaults for the remaining
+// fields.
+func NewMsgXVersion() *MsgXVersion {
+	return &MsgXVersion{}
+}

--- a/wire/msgxversion_test.go
+++ b/wire/msgxversion_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2019 The bchd developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// TestXVersion tests the MsgXVersion API.
+func TestXVersion(t *testing.T) {
+	pver := ProtocolVersion
+
+	// Ensure the command is expected value.
+	wantCmd := "xversion"
+	msg := NewMsgXVersion()
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("NewMsgXVersion: wrong command - got %v want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload is expected value.
+	wantPayload := uint32(100000)
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+}
+
+// TestXVersionWire tests the MsgXVersion wire encode and decode for various
+// protocol versions.
+func TestXVersionWire(t *testing.T) {
+	msgXVersion := NewMsgXVersion()
+	msgXVersionEncoded := []byte{}
+
+	tests := []struct {
+		in   *MsgXVersion    // Message to encode
+		out  *MsgXVersion    // Expected decoded message
+		buf  []byte          // Wire encoding
+		pver uint32          // Protocol version for wire encoding
+		enc  MessageEncoding // Message encoding format
+	}{
+		// Latest protocol version.
+		{
+			msgXVersion,
+			msgXVersion,
+			msgXVersionEncoded,
+			ProtocolVersion,
+			BaseEncoding,
+		},
+
+		// Protocol version BIP0035Version.
+		{
+			msgXVersion,
+			msgXVersion,
+			msgXVersionEncoded,
+			BIP0035Version,
+			BaseEncoding,
+		},
+
+		// Protocol version BIP0031Version.
+		{
+			msgXVersion,
+			msgXVersion,
+			msgXVersionEncoded,
+			BIP0031Version,
+			BaseEncoding,
+		},
+
+		// Protocol version NetAddressTimeVersion.
+		{
+			msgXVersion,
+			msgXVersion,
+			msgXVersionEncoded,
+			NetAddressTimeVersion,
+			BaseEncoding,
+		},
+
+		// Protocol version MultipleAddressVersion.
+		{
+			msgXVersion,
+			msgXVersion,
+			msgXVersionEncoded,
+			MultipleAddressVersion,
+			BaseEncoding,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BchEncode(&buf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BchEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BchEncode #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg MsgXVersion
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BchDecode(rbuf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BchDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, test.out) {
+			t.Errorf("BchDecode #%d\n got: %s want: %s", i,
+				spew.Sdump(msg), spew.Sdump(test.out))
+			continue
+		}
+	}
+}


### PR DESCRIPTION
This adds a basic stub for xversion messages so we don't disconnect BU clients as reported in https://github.com/gcash/bchd/issues/184

This implements:
- Support for xversion and xverack message types.
- Replies to xversion messages with an xverack.
- Makes sure the xversion message is below the size limit.
- Makes sure only one xversion is received per client.

This does not actually implement the xversion message parsing or pull any data from the xversion.

Can confirm connections to BU nodes with these changes.

```
{
             "104.199.108.13:8333" => "/Bitcoin ABC:0.18.3(EB32.0)/",
               "47.91.95.148:8333" => "/Bitcoin ABC:0.18.3(EB32.0)/",
             "73.243.165.156:8333" => "/BUCash:1.5.1(EB32; AD12)/",
             "198.204.229.34:8333" => "/Bitcoin ABC:0.19.0(EB32.0)/",
              "74.72.248.101:8333" => "/bchd:0.14.0(EB32.0)/",
               "18.179.32.86:8333" => "/Bitcoin ABC:0.18.7(EB32.0)/",
    "[2a01:4f9:c010:3efb::1]:8333" => "/Bitcoin ABC:0.19.1(EB32.0)/",
             "149.202.211.17:8333" => "/Bitcoin ABC:0.17.1(EB32.0)/",
            "115.187.213.139:8333" => "/BUCash:1.5.1(EB32; AD12)/",
            "104.163.145.133:8334" => "/BUCash:1.5.1(EB32; AD12)/",
              "107.172.9.209:8333" => "/BUCash:1.5.1(EB32; AD12)/",
             "104.248.25.255:8333" => "/BUCash:1.5.1(EB32; AD12)/",
            "108.200.255.200:8338" => "/BUCash:1.5.1(EB32; AD8)/",
             "121.122.79.151:8333" => "/BUCash:1.5.1(EB32; AD12)/"
}
```