### PR TITLE
Create indexer migrations

### DIFF
--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -597,6 +597,15 @@ func (idx *AddrIndex) Init() error {
 	return nil
 }
 
+// Migrate is only provided to satisfy the Indexer interface as there is nothing to
+// migrate this index.
+//
+// This is part of the Indexer interface.
+func (idx *AddrIndex) Migrate(db database.DB, interrupt <-chan struct{}) error {
+	// Nothing to do.
+	return nil
+}
+
 // Key returns the database key to use for the index as a byte slice.
 //
 // This is part of the Indexer interface.

--- a/blockchain/indexers/common.go
+++ b/blockchain/indexers/common.go
@@ -45,6 +45,11 @@ type Indexer interface {
 	// to be created for the first time.
 	Create(dbTx database.Tx) error
 
+	// Migrate is invoked after Init and allows each index the opportunity
+	// to perform any migrations as necessary. This should be a noop if
+	// there are no migrations to perform.
+	Migrate(db database.DB, interrupt <-chan struct{}) error
+
 	// Init is invoked when the index manager is first initializing the
 	// index.  This differs from the Create method in that it is called on
 	// every load, including the case the index was just created.

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -270,6 +270,13 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 		}
 	}
 
+	// Migrate each index if necessary.
+	for _, indexer := range m.enabledIndexes {
+		if err := indexer.Migrate(m.db, interrupt); err != nil {
+			return err
+		}
+	}
+
 	// Rollback indexes to the main chain if their tip is an orphaned fork.
 	// This is fairly unlikely, but it can happen if the chain is
 	// reorganized while the index is disabled.  This has to be done in

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -352,6 +352,15 @@ func (idx *TxIndex) Init() error {
 	return nil
 }
 
+// Migrate is only provided to satisfy the Indexer interface as there is nothing to
+// migrate this index.
+//
+// This is part of the Indexer interface.
+func (idx *TxIndex) Migrate(db database.DB, interrupt <-chan struct{}) error {
+	// Nothing to do.
+	return nil
+}
+
 // Key returns the database key to use for the index as a byte slice.
 //
 // This is part of the Indexer interface.


### PR DESCRIPTION
This commit creates a Migrate method in the indexer interface. It also adds
a migration to the cfilter index which just drops the index and rebuilds. The
purpose it make sure all nodes are using the same index as the filtering code
has changed recently and it appears some nodes have a different index.