### PR TITLE
Fix bug in OP_CAT

### DIFF
--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -1411,7 +1411,9 @@ func opcodeCat(op *parsedOpcode, vm *Engine) error {
 	if err != nil {
 		return err
 	}
-	c := append(a, b...)
+	c := make([]byte, len(a)+len(b))
+	copy(c[:len(a)], a)
+	copy(c[len(a):], b)
 	if len(c) > MaxScriptElementSize {
 		str := fmt.Sprintf("concatenated size %d exceeds max allowed size %d",
 			len(c), MaxScriptElementSize)


### PR DESCRIPTION
bchd choked on transaction [b0f79eea9e05fe83e198efff4363e3e347d5efd77a22fbf39a09347162fb2560](https://www.blockchain.com/bch/tx/b0f79eea9e05fe83e198efff4363e3e347d5efd77a22fbf39a09347162fb2560).

It contained an extremely long script sig with hundreds of opcodes. When tracing the stack execution it was determined that OP_CAT was mutating items deeper in the stack. This commit fixes the bug. 

Nodes will need to run 
```
bchctl reconsiderblock 0000000000000000001df2299a0d705bc95df7045398a32d1dea5ccff7bb9fb6
```
to fix their chain.

Thanks to Mark Lundeberg for pinpointing the bug. 