### PR TITLE
[Fix] Update getinfo rpc call to return correct protocol version

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -77,7 +77,7 @@ const (
 	gbtRegenerateSeconds = 60
 
 	// maxProtocolVersion is the max protocol version the server supports.
-	maxProtocolVersion = wire.FeeFilterVersion
+	maxProtocolVersion = wire.NoValidationRelayVersion
 )
 
 var (


### PR DESCRIPTION
This was not updated when we added CompactBlocks support. Now it returns `70015` as it should. =)