### PR TITLE
Override utxo entry in reorg case

### DIFF
--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -470,12 +470,14 @@ func (s *utxoCache) Commit(view *UtxoViewpoint) error {
 		// the UTXO set, only to have a future block add it back. In that case it could
 		// be going from being marked spent to needing to be marked unspent so we handle
 		// that case by overriding here.
+		override := false
 		if ourEntry.IsSpent() && !entry.IsSpent() {
-			ourEntry = entry
+			ourEntry = entry.Clone()
+			override = true
 		}
 
 		// Store the entry we don't know.
-		if err := s.addEntry(outpoint, ourEntry, false); err != nil {
+		if err := s.addEntry(outpoint, ourEntry, override); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The code here wants to override the existing entry in the cache in the reorg case. However, the override bool was left to false so `addEntry` wouldn't actually do the override. 

Also, by setting `ourEntry` to `entry` rather than a _copy_ of `entry` any modifications to `entry` performed later (which happens at least when the view is pruned) will unintentionally modify the cache.