### PR TITLE
Fix bug loading coinbase transacations in gRPC API

### DIFF
--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -1304,6 +1304,9 @@ func (s *GrpcServer) setInputMetadata(tx *pb.Transaction) error {
 		if err != nil {
 			return status.Error(codes.Internal, "error marshaling chainhash")
 		}
+		if ch.IsEqual(&chainhash.Hash{}) { // Coinbase txs don't have an input.
+			continue
+		}
 		if prevTx, ok := inputTxMap[*ch]; ok {
 			tx.Inputs[i].Value = prevTx.TxOut[in.Outpoint.Index].Value
 			tx.Inputs[i].PreviousScript = prevTx.TxOut[in.Outpoint.Index].PkScript


### PR DESCRIPTION
The GetTransaction RPC tries to load input metadata for each input. If it's a
coinbase transaction there is no metadata and this was causing an error.