### PR TITLE
Fix bug in blocktemplate generation

### DIFF
--- a/mining/mining.go
+++ b/mining/mining.go
@@ -287,7 +287,7 @@ func createCoinbaseTx(params *chaincfg.Params, coinbaseScript []byte, nextBlockH
 	// Make sure the coinbase is above the minimum size threshold.
 	if tx.SerializeSize() < blockchain.MinTransactionSize {
 		tx.TxIn[0].SignatureScript = append(tx.TxIn[0].SignatureScript,
-			make([]byte, blockchain.MinTransactionSize-tx.SerializeSize()-1)...)
+			make([]byte, blockchain.MinTransactionSize-(tx.SerializeSize()-1))...)
 	}
 	return bchutil.NewTx(tx), nil
 }

--- a/mining/mining_test.go
+++ b/mining/mining_test.go
@@ -6,6 +6,9 @@ package mining
 
 import (
 	"container/heap"
+	"github.com/gcash/bchd/blockchain"
+	"github.com/gcash/bchd/chaincfg"
+	"github.com/gcash/bchd/txscript"
 	"math/rand"
 	"testing"
 
@@ -106,5 +109,25 @@ func TestTxFeePrioHeap(t *testing.T) {
 				highest.feePerKB, highest.priority)
 		}
 		highest = prioItem
+	}
+}
+
+// Test_createCoinbaseTx tests that the coinbase is padded to be over the minimum transaction size.
+func Test_createCoinbaseTx(t *testing.T) {
+	coinbaseScript, err := standardCoinbaseScript(584412, 123456789)
+	if err != nil {
+		t.Fatal(err)
+	}
+	miningAddr, err := bchutil.DecodeAddress("qr0ayr8hdlg6zl7kcn8mgc8cz04aczyw4567fpu8rl", &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coinbase, err := createCoinbaseTx(&chaincfg.MainNetParams, coinbaseScript[:len(coinbaseScript)-2], 584412, miningAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = blockchain.CheckTransactionSanity(coinbase, true, txscript.StandardVerifyFlags)
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
The template calculated the padding for the coinbase incorrectly and some coinbases could end up under the 100 byte minimum.

fixes #237