### PR TITLE
Fix CORS for grpc-web

### DIFF
--- a/grpcserver.go
+++ b/grpcserver.go
@@ -38,7 +38,7 @@ func newGrpcServer(netAddrs []net.Addr, rpcCfg *bchrpc.GrpcServerConfig, svr *se
 		rpcCfg.Server = server
 
 		handler := func(resp http.ResponseWriter, req *http.Request) {
-			if wrappedGrpc.IsGrpcWebRequest(req) {
+			if wrappedGrpc.IsGrpcWebRequest(req) || wrappedGrpc.IsAcceptableGrpcCorsRequest(req) {
 				wrappedGrpc.ServeHTTP(resp, req)
 			} else {
 				server.ServeHTTP(resp, req)


### PR DESCRIPTION
Grpcserver did not catch the pre-flight OPTIONS request as CORS and served it with plain http server while it should be served by wrappedGrpc with CORS. This commit should fix that.