### PR TITLE
Fix bug in schnorr signature verification

### DIFF
--- a/bchec/signature.go
+++ b/bchec/signature.go
@@ -146,7 +146,7 @@ func verifySchnorr(pubKey *PublicKey, hash []byte, r *big.Int, s *big.Int) bool 
 	// Check R values match
 	// rx ≠ rz^2 * r mod p
 	fieldR := new(fieldVal).SetByteSlice(r.Bytes())
-	return rx.Equals(rz.Square().Mul(fieldR))
+	return rx.Normalize().Equals(rz.Square().Mul(fieldR).Normalize())
 }
 
 // IsEqual compares this Signature instance to the one passed, returning true


### PR DESCRIPTION
Node chocked while validating the schnorr signature for 41c2a2340c2aae0e22bbd2452712af5dfbb7304a249d470410d577277ff92357 input 0.

To fix node after this commit is merged:

`bchctl reconsiderblock 000000000000000000788b661a692dfbcd8043228758468fe3ce109aa1c69036`