### PR TITLE
[Fix] Make sure downstream peers get new blocks on reorg

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1183,6 +1183,13 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		if err != nil {
 			return err
 		}
+
+		// Notify other peers that this block was accepted. Since it was
+		// originally seen as an orphan the accept message was never sent
+		// to downstream peers.
+		b.chainLock.Unlock()
+		b.sendNotification(NTBlockAccepted, block)
+		b.chainLock.Lock()
 	}
 
 	// Log the point where the chain forked and old and new best chain


### PR DESCRIPTION
This should fix issue https://github.com/gcash/bchd/issues/262

Currently we only send blocks to downstream nodes if it is accepted. Therefore, if we get blocks that are not accepted, and there is a reorg, those notifications are never sent.

This merely makes sure during a reorg to send blocks to downstream nodes after we connect them to our main chain again. That way we are guaranteed to relay all important blocks to downstream peers and prevent them from hanging.