### PR TITLE
[Bug] Check for spent status in mempool

### DIFF
--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -977,6 +977,12 @@ func (s *GrpcServer) GetUnspentOutput(ctx context.Context, req *pb.GetUnspentOut
 		scriptPubkey = tx.MsgTx().TxOut[req.Index].PkScript
 		coinbase = blockchain.IsCoinBase(tx)
 	} else {
+		if req.IncludeMempool {
+			spendingTx := s.txMemPool.CheckSpend(*op)
+			if spendingTx != nil {
+				return nil, status.Error(codes.NotFound, "utxo spent in mempool")
+			}
+		}
 		entry, err := s.chain.FetchUtxoEntry(*op)
 		if err != nil {
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
 	golang.org/x/text v0.3.0
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
 	google.golang.org/grpc v1.20.1
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect


### PR DESCRIPTION
Fixes https://github.com/gcash/bchd/issues/280

Since HaveTransaction returns false for transactions spent in the mempool, we needed to add an additional check. The code isn't super pretty, but it does fix the issue reported. Tested and deployed on bchd.greyh.at.
