### PR TITLE
Don't migrate indexes if pruned

### DIFF
--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -271,9 +271,11 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 	}
 
 	// Migrate each index if necessary.
-	for _, indexer := range m.enabledIndexes {
-		if err := indexer.Migrate(m.db, interrupt); err != nil {
-			return err
+	if !chain.IsPruned() {
+		for _, indexer := range m.enabledIndexes {
+			if err := indexer.Migrate(m.db, interrupt); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -3114,7 +3114,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		s.addrIndex = indexers.NewAddrIndex(db, chainParams)
 		indexes = append(indexes, s.addrIndex)
 	}
-	if !cfg.NoCFilters {
+	if !cfg.FastSync && !cfg.NoCFilters {
 		indxLog.Info("Committed filter index is enabled")
 		s.cfIndex = indexers.NewCfIndex(db, chainParams)
 		indexes = append(indexes, s.cfIndex)


### PR DESCRIPTION
Neutrino technically cannot sync from fasysynced nodes since the fastsync nodes are calculating the filter headers incorrectly. This is because the filter header contains the hash of the previous header but the fastsync nodes don't know the hash prior to the checkpoint. So the filter headers are incorrect for every block going forward. 

In theory we can still index and migrate pruned (but not fastsynced) nodes since they do calculate filters from genesis. This would require figuring out the height of the first block that is stored and migrating from there. This is not easy to do however. 