### PR TITLE
[Bug] Allow wire.MsgTx objects to be GC'd before UTXO cache is flushed

### DIFF
--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -180,9 +180,11 @@ func addTxOuts(view utxoView, tx *bchutil.Tx, blockHeight int32, overwrite bool)
 		}
 
 		// Create a new entry from the output.
+		pkScript := make([]byte, len(txOut.PkScript))
+		copy(pkScript, txOut.PkScript)
 		entry := &UtxoEntry{
 			amount:      txOut.Value,
-			pkScript:    txOut.PkScript,
+			pkScript:    pkScript,
 			blockHeight: blockHeight,
 			packedFlags: tfModified,
 		}
@@ -326,9 +328,12 @@ func disconnectTransactions(view utxoView, block *bchutil.Block, stxos []SpentTx
 			stxo := &stxos[stxoIdx]
 			stxoIdx--
 
+			pkScript := make([]byte, len(stxo.PkScript))
+			copy(pkScript, stxo.PkScript)
+
 			entry := &UtxoEntry{
 				amount:      stxo.Amount,
-				pkScript:    stxo.PkScript,
+				pkScript:    pkScript,
 				blockHeight: stxo.Height,
 				packedFlags: tfModified,
 			}


### PR DESCRIPTION
I did some profiling work on bchd and noticed that when UtxoEntry objects are built we are passing in a pointer to a slice of bytes containing the PkScript. This caused wire.MsgTx objects to not GC until the UTXO cache was flushed. While this didn't leak, it did cause bchd to have higher memory usage than necessary. In my testing this reduces memory usage about 200MB with a 450MB UTXO cache.

If people are using larger cache sizes then this would be even worse. The simple fix is just to copy the bytes of the PkScript and that allows the GC to reclaim the original MsgTx.