### PR TITLE
Set indexManger to nil if chain is pruned

### DIFF
--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -271,11 +271,9 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 	}
 
 	// Migrate each index if necessary.
-	if !chain.IsPruned() {
-		for _, indexer := range m.enabledIndexes {
-			if err := indexer.Migrate(m.db, interrupt); err != nil {
-				return err
-			}
+	for _, indexer := range m.enabledIndexes {
+		if err := indexer.Migrate(m.db, interrupt); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
The fast sync feature is not playing nice with the recent migration due to
the chain being pruned. If someone runs their node without the fastsync flag
after previously doing so, it will get into a bad state.

This commit sets the indexManger to nil inside the blockchain package if it
was ever run in fast sync mode previously.

closes #294