### PR TITLE
[Bug] Add notificationLock mutex to protect against double unlock

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -84,9 +84,11 @@ func (b *BlockChain) maybeAcceptBlock(block *bchutil.Block, flags BehaviorFlags)
 	// Notify the caller that the new block was accepted into the block
 	// chain.  The caller would typically want to react by relaying the
 	// inventory to other peers.
+	b.notificationLock.Lock()
 	b.chainLock.Unlock()
 	b.sendNotification(NTBlockAccepted, block)
 	b.chainLock.Lock()
+	b.notificationLock.Unlock()
 
 	return isMainChain, nil
 }


### PR DESCRIPTION
Hopefully fixes the panic we saw on reorg. Should prevent a double unlock from ever occurring.