### PR TITLE
[Chore] Warn instead of exit on binding a non localhost address for rpc/gRPC

### DIFF
--- a/config.go
+++ b/config.go
@@ -981,13 +981,10 @@ func loadConfig() (*config, []string, error) {
 				return nil, nil, err
 			}
 			if _, ok := allowedTLSListeners[host]; !ok {
-				str := "%s: the --notls option may not be used " +
+				str := "%s: the --notls option is not recommended " +
 					"when binding RPC to non localhost " +
 					"addresses: %s"
-				err := fmt.Errorf(str, funcName, addr)
-				fmt.Fprintln(os.Stderr, err)
-				fmt.Fprintln(os.Stderr, usageMessage)
-				return nil, nil, err
+				bchdLog.Warnf(str, funcName, addr)
 			}
 		}
 		for _, addr := range cfg.GrpcListeners {
@@ -1001,13 +998,10 @@ func loadConfig() (*config, []string, error) {
 				return nil, nil, err
 			}
 			if _, ok := allowedTLSListeners[host]; !ok {
-				str := "%s: the --notls option may not be used " +
+				str := "%s: the --notls option is not recommended " +
 					"when binding gRPC to non localhost " +
 					"addresses: %s"
-				err := fmt.Errorf(str, funcName, addr)
-				fmt.Fprintln(os.Stderr, err)
-				fmt.Fprintln(os.Stderr, usageMessage)
-				return nil, nil, err
+				bchdLog.Warnf(str, funcName, addr)
 			}
 		}
 	}


### PR DESCRIPTION
For people that use SSL terminated load balancers it is important to only warn if they bind to a non-localhost address. We shouldn't assume how someone has their infra setup.