### PR TITLE
[Bug] Refactor wallet.go to remove hard coded MainNetParams

### DIFF
--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	"github.com/gcash/bchd/btcjson"
-	"github.com/gcash/bchd/chaincfg"
 	"github.com/gcash/bchd/chaincfg/chainhash"
 	"github.com/gcash/bchd/wire"
 	"github.com/gcash/bchutil"
@@ -808,20 +807,20 @@ type FutureAddMultisigAddressResult chan *response
 // Receive waits for the response promised by the future and returns the
 // multisignature address that requires the specified number of signatures for
 // the provided addresses.
-func (r FutureAddMultisigAddressResult) Receive() (bchutil.Address, error) {
+func (r FutureAddMultisigAddressResult) Receive() (string, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Unmarshal result as a addmultisigaddress result object.
 	var addmultisigRes btcjson.AddMultisigAddressResult
 	err = json.Unmarshal(res, &addmultisigRes)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return bchutil.DecodeAddress(addmultisigRes.Address, &chaincfg.MainNetParams)
+	return addmultisigRes.Address, nil
 }
 
 // AddMultisigAddressAsync returns an instance of a type that can be used to get
@@ -842,8 +841,15 @@ func (c *Client) AddMultisigAddressAsync(requiredSigs int, addresses []bchutil.A
 // AddMultisigAddress adds a multisignature address that requires the specified
 // number of signatures for the provided addresses to the wallet.
 func (c *Client) AddMultisigAddress(requiredSigs int, addresses []bchutil.Address, account string) (bchutil.Address, error) {
-	return c.AddMultisigAddressAsync(requiredSigs, addresses,
+	var addr string
+	var err error
+	addr, err = c.AddMultisigAddressAsync(requiredSigs, addresses,
 		account).Receive()
+	if err != nil {
+		return nil, err
+	}
+
+	return bchutil.DecodeAddress(addr, c.chainParams)
 }
 
 // FutureCreateMultisigResult is a future promise to deliver the result of a
@@ -922,20 +928,20 @@ type FutureGetNewAddressResult chan *response
 
 // Receive waits for the response promised by the future and returns a new
 // address.
-func (r FutureGetNewAddressResult) Receive() (bchutil.Address, error) {
+func (r FutureGetNewAddressResult) Receive() (string, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Unmarshal result as a string.
 	var addr string
 	err = json.Unmarshal(res, &addr)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return bchutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return addr, nil
 }
 
 // GetNewAddressAsync returns an instance of a type that can be used to get the
@@ -950,7 +956,14 @@ func (c *Client) GetNewAddressAsync(account string) FutureGetNewAddressResult {
 
 // GetNewAddress returns a new address.
 func (c *Client) GetNewAddress(account string) (bchutil.Address, error) {
-	return c.GetNewAddressAsync(account).Receive()
+	var addr string
+	var err error
+	addr, err = c.GetNewAddressAsync(account).Receive()
+	if err != nil {
+		return nil, err
+	}
+
+	return bchutil.DecodeAddress(addr, c.chainParams)
 }
 
 // FutureGetRawChangeAddressResult is a future promise to deliver the result of
@@ -960,20 +973,20 @@ type FutureGetRawChangeAddressResult chan *response
 // Receive waits for the response promised by the future and returns a new
 // address for receiving change that will be associated with the provided
 // account.  Note that this is only for raw transactions and NOT for normal use.
-func (r FutureGetRawChangeAddressResult) Receive() (bchutil.Address, error) {
+func (r FutureGetRawChangeAddressResult) Receive() (string, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Unmarshal result as a string.
 	var addr string
 	err = json.Unmarshal(res, &addr)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return bchutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return addr, nil
 }
 
 // GetRawChangeAddressAsync returns an instance of a type that can be used to
@@ -990,7 +1003,14 @@ func (c *Client) GetRawChangeAddressAsync(account string) FutureGetRawChangeAddr
 // associated with the provided account.  Note that this is only for raw
 // transactions and NOT for normal use.
 func (c *Client) GetRawChangeAddress(account string) (bchutil.Address, error) {
-	return c.GetRawChangeAddressAsync(account).Receive()
+	var addr string
+	var err error
+	addr, err = c.GetRawChangeAddressAsync(account).Receive()
+	if err != nil {
+		return nil, err
+	}
+
+	return bchutil.DecodeAddress(addr, c.chainParams)
 }
 
 // FutureGetAccountAddressResult is a future promise to deliver the result of a
@@ -999,20 +1019,20 @@ type FutureGetAccountAddressResult chan *response
 
 // Receive waits for the response promised by the future and returns the current
 // Bitcoin address for receiving payments to the specified account.
-func (r FutureGetAccountAddressResult) Receive() (bchutil.Address, error) {
+func (r FutureGetAccountAddressResult) Receive() (string, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Unmarshal result as a string.
 	var addr string
 	err = json.Unmarshal(res, &addr)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return bchutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return addr, nil
 }
 
 // GetAccountAddressAsync returns an instance of a type that can be used to get
@@ -1028,7 +1048,14 @@ func (c *Client) GetAccountAddressAsync(account string) FutureGetAccountAddressR
 // GetAccountAddress returns the current Bitcoin address for receiving payments
 // to the specified account.
 func (c *Client) GetAccountAddress(account string) (bchutil.Address, error) {
-	return c.GetAccountAddressAsync(account).Receive()
+	var addr string
+	var err error
+	addr, err = c.GetAccountAddressAsync(account).Receive()
+	if err != nil {
+		return nil, err
+	}
+
+	return bchutil.DecodeAddress(addr, c.chainParams)
 }
 
 // FutureGetAccountResult is a future promise to deliver the result of a
@@ -1102,7 +1129,7 @@ type FutureGetAddressesByAccountResult chan *response
 
 // Receive waits for the response promised by the future and returns the list of
 // addresses associated with the passed account.
-func (r FutureGetAddressesByAccountResult) Receive() ([]bchutil.Address, error) {
+func (r FutureGetAddressesByAccountResult) Receive() ([]string, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
@@ -1115,17 +1142,7 @@ func (r FutureGetAddressesByAccountResult) Receive() ([]bchutil.Address, error) 
 		return nil, err
 	}
 
-	addrs := make([]bchutil.Address, 0, len(addrStrings))
-	for _, addrStr := range addrStrings {
-		addr, err := bchutil.DecodeAddress(addrStr,
-			&chaincfg.MainNetParams)
-		if err != nil {
-			return nil, err
-		}
-		addrs = append(addrs, addr)
-	}
-
-	return addrs, nil
+	return addrStrings, nil
 }
 
 // GetAddressesByAccountAsync returns an instance of a type that can be used to
@@ -1141,7 +1158,23 @@ func (c *Client) GetAddressesByAccountAsync(account string) FutureGetAddressesBy
 // GetAddressesByAccount returns the list of addresses associated with the
 // passed account.
 func (c *Client) GetAddressesByAccount(account string) ([]bchutil.Address, error) {
-	return c.GetAddressesByAccountAsync(account).Receive()
+	var addrStrings []string
+	var err error
+	addrStrings, err = c.GetAddressesByAccountAsync(account).Receive()
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := make([]bchutil.Address, 0, len(addrStrings))
+	for _, addrStr := range addrStrings {
+		addr, err := bchutil.DecodeAddress(addrStr, c.chainParams)
+		if err != nil {
+			return nil, err
+		}
+		addrs = append(addrs, addr)
+	}
+
+	return addrs, nil
 }
 
 // FutureMoveResult is a future promise to deliver the result of a MoveAsync,


### PR DESCRIPTION
Now you can configure an rpc client with the required network. If the param isn't passed in it assumes mainnet. This removes the hard coded network settings in wallet.go!

Based off the work at https://github.com/btcsuite/btcd/pull/1467/files

Fixes: https://github.com/gcash/bchd/issues/313