### PR TITLE
[Feature] Update ParsePkScript to support multiple networks

### DIFF
--- a/txscript/pkscript.go
+++ b/txscript/pkscript.go
@@ -57,10 +57,16 @@ type PkScript struct {
 // ParsePkScript parses an output script into the PkScript struct.
 // ErrUnsupportedScriptType is returned when attempting to parse an unsupported
 // script type.
-func ParsePkScript(pkScript []byte) (PkScript, error) {
+func ParsePkScript(pkScript []byte, chainParams *chaincfg.Params) (PkScript, error) {
 	var outputScript PkScript
+
+	// Default to mainnet if no chainParams are provided.
+	if chainParams == nil {
+		chainParams = &chaincfg.MainNetParams
+	}
+
 	scriptClass, _, _, err := ExtractPkScriptAddrs(
-		pkScript, &chaincfg.MainNetParams,
+		pkScript, chainParams,
 	)
 	if err != nil {
 		return outputScript, fmt.Errorf("unable to parse script type: "+
@@ -131,13 +137,13 @@ func (s PkScript) String() string {
 }
 
 // ComputePkScript computes the pkScript of an transaction output by looking at
-// the transaction input's signature script or witness.
+// the transaction input's signature script.
 //
 // NOTE: Only P2PKH, and P2SH redeem scripts are supported.
 func ComputePkScript(sigScript []byte) (PkScript, error) {
 	var pkScript PkScript
 
-	// Ensure that either an input's signature script or a witness was
+	// Ensure that either an input's signature script was
 	// provided.
 	if len(sigScript) == 0 {
 		return pkScript, ErrUnsupportedScriptType

--- a/txscript/pkscript_test.go
+++ b/txscript/pkscript_test.go
@@ -100,7 +100,7 @@ func TestParsePkScript(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			pkScript, err := ParsePkScript(test.pkScript)
+			pkScript, err := ParsePkScript(test.pkScript, nil)
 			switch {
 			case err != nil && test.valid:
 				t.Fatalf("unable to parse valid pkScript=%x: %v",


### PR DESCRIPTION
Just updated `ParsePkScript` to accept the chain params as a parameter. That way it can support non-mainnet networks.

I grepped through all the other projects, it doesn't seem like anyone uses it, so the function signature change shouldn't impact our other repos.