### PR TITLE
Check for nil req in SubscribeTransactionStream

### DIFF
--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -1282,6 +1282,9 @@ func (s *GrpcServer) SubscribeTransactionStream(stream pb.Bchrpc_SubscribeTransa
 	for {
 		select {
 		case req := <-requests:
+			if req == nil {
+				return nil
+			}
 			includeMempool = req.IncludeMempool
 			includeBlocks = req.IncludeInBlock
 			serializeTx = req.SerializeTx

--- a/txscript/engine.go
+++ b/txscript/engine.go
@@ -290,7 +290,7 @@ func (vm *Engine) CheckErrorCondition(finalScript bool) error {
 	}
 
 	// If the script is a segwit exemption we exit before checking the cleanstack
-	// rule and before poping the top stack item off the stack and verifying that
+	// rule and before popping the top stack item off the stack and verifying that
 	// it is non-zero. In other words, if this is a p2sh segwit script and the
 	// redeem script hashed to the correct hash in the PKScript then we consider
 	// the script valid. Even if the stop stack item is zero or there is more


### PR DESCRIPTION
There can be a panic when a client disconnects from SubscribeTransactionStream due to a race. This checks for nil in the request.