### PR TITLE
Improve memory usage of GetAddressUnspentOutputs RPC call

### DIFF
--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -47,7 +47,7 @@ const (
 
 	bytePerKb = 1000
 
-	bchPerSatoshi = 1E-8
+	bchPerSatoshi = 1e-8
 )
 
 var (


### PR DESCRIPTION
This commit improves the memory usage of the RPC call by checking the utxos
after each batch rather than loading all transsactions into memory.

We also enforce a max query size of 10,000 on the GetAddressTransactions
and GetRawAddressTransactions RPCs.