### PR TITLE
Remove dead and useless DNS seeds

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -446,8 +446,6 @@ var TestNet3Params = Params{
 		{"testnet-seed.bchd.cash", true},
 		{"testnet-seed.bitcoinabc.org", true},
 		{"testnet-seed-abc.bitcoinforks.org", true},
-		{"testnet-seed.bitprim.org", true},
-		{"testnet-seed.deadalnix.me", true},
 		{"testnet-seeder.criptolayer.net", true},
 	},
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -238,8 +238,6 @@ var MainNetParams = Params{
 		{"seed.bitcoinabc.org", true},
 		{"seed-abc.bitcoinforks.org", true},
 		{"btccash-seeder.bitcoinunlimited.info", true},
-		{"seed.bitprim.org", true},
-		{"seed.deadalnix.me", true},
 	},
 
 	// Chain parameters

--- a/chaincfg/params_test.go
+++ b/chaincfg/params_test.go
@@ -41,8 +41,6 @@ func TestSeeds(t *testing.T) {
 		{"seed.bitcoinabc.org", true},
 		{"seed-abc.bitcoinforks.org", true},
 		{"btccash-seeder.bitcoinunlimited.info", true},
-		{"seed.bitprim.org", true},
-		{"seed.deadalnix.me", true},
 	}
 
 	if MainNetParams.DNSSeeds == nil {


### PR DESCRIPTION
Remove long dead DNS seed seed.bitprim.org.
Remove DNS seed seed.deadalnix.me returning only itself as a node.