### PR TITLE
Add ipfs.io as another public ipfs gateway for utxo snapshots

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -298,6 +298,7 @@ var MainNetParams = Params{
 			UtxoSetSources: []string{
 				"http://localhost:8080/ipfs/QmQECm1yUgKh7oQg2syCFo5BLvhFSSH9m95fw41b3GTrXV",
 				"https://ipfs.greyh.at/ipfs/QmQECm1yUgKh7oQg2syCFo5BLvhFSSH9m95fw41b3GTrXV",
+				"https://ipfs.io/ipfs/QmQECm1yUgKh7oQg2syCFo5BLvhFSSH9m95fw41b3GTrXV",
 			},
 		},
 		{
@@ -308,6 +309,7 @@ var MainNetParams = Params{
 			UtxoSetSources: []string{
 				"http://localhost:8080/ipfs/QmXkBQJrMKkCKNbwv4m5xtnqwU9Sq7kucPigvZW8mWxcrv",
 				"https://ipfs.greyh.at/ipfs/QmXkBQJrMKkCKNbwv4m5xtnqwU9Sq7kucPigvZW8mWxcrv",
+				"https://ipfs.io/ipfs/QmXkBQJrMKkCKNbwv4m5xtnqwU9Sq7kucPigvZW8mWxcrv",
 			},
 		},
 		{
@@ -318,6 +320,7 @@ var MainNetParams = Params{
 			UtxoSetSources: []string{
 				"http://localhost:8080/ipfs/QmZQFi5kiY1cAu6hEpLCEaAZ3FX1CtmFVtE8DiLvkYNg62",
 				"https://ipfs.greyh.at/ipfs/QmZQFi5kiY1cAu6hEpLCEaAZ3FX1CtmFVtE8DiLvkYNg62",
+				"https://ipfs.io/ipfs/QmZQFi5kiY1cAu6hEpLCEaAZ3FX1CtmFVtE8DiLvkYNg62",
 			},
 		},
 	},


### PR DESCRIPTION
Recently my IPFS server has been getting hammered. Unfortunately it isn't just for our UTXO snapshots, but a LOT of other requests as well.

While I do want to seed the UTXO snapshots, I think its good we have a fallback just in case I disable the front facing web daemon due to abuse.

Then people can still fetch them from another location, and I can reduce the insane bandwidth ipfs is taking on my cluster.

NOTE: My underlying ipfs node will still be up serving up the pinned files!