### PR TITLE
[Bug] Update coinbase tx padding and fix validations for submitBlock

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -7,6 +7,7 @@ package blockchain
 import (
 	"fmt"
 
+	"github.com/gcash/bchd/chaincfg/chainhash"
 	"github.com/gcash/bchd/database"
 	"github.com/gcash/bchutil"
 )
@@ -21,11 +22,9 @@ import (
 // their documentation for how the flags modify their behavior.
 //
 // This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) maybeAcceptBlock(block *bchutil.Block, flags BehaviorFlags) (bool, error) {
+func (b *BlockChain) maybeAcceptBlock(block *bchutil.Block, prevHash *chainhash.Hash, prevNode *blockNode, flags BehaviorFlags) (bool, error) {
 	// The height of this block is one more than the referenced previous
 	// block.
-	prevHash := &block.MsgBlock().Header.PrevBlock
-	prevNode := b.index.LookupNode(prevHash)
 	if prevNode == nil {
 		str := fmt.Sprintf("previous block %s is unknown", prevHash)
 		return false, ruleError(ErrPreviousBlockUnknown, str)

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -299,13 +299,12 @@ func (g *testGenerator) createCoinbaseTx(blockHeight int32) *wire.MsgTx {
 		Value:    blockchain.CalcBlockSubsidy(blockHeight, g.params),
 		PkScript: opTrueScript,
 	})
+
 	if tx.SerializeSize() < blockchain.MinTransactionSize {
-		padLen := blockchain.MinTransactionSize - tx.SerializeSize()
-		tx.AddTxOut(&wire.TxOut{
-			Value:    0,
-			PkScript: opReturnScript(make([]byte, padLen)),
-		})
+		tx.TxIn[0].SignatureScript = append(tx.TxIn[0].SignatureScript,
+			make([]byte, blockchain.MinTransactionSize-tx.SerializeSize())...)
 	}
+
 	return tx
 }
 

--- a/integration/rpctest/blockgen.go
+++ b/integration/rpctest/blockgen.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"time"
 
+	"sort"
+
 	"github.com/gcash/bchd/blockchain"
 	"github.com/gcash/bchd/chaincfg"
 	"github.com/gcash/bchd/chaincfg/chainhash"
@@ -18,7 +20,6 @@ import (
 	"github.com/gcash/bchd/txscript"
 	"github.com/gcash/bchd/wire"
 	"github.com/gcash/bchutil"
-	"sort"
 )
 
 // solveBlock attempts to find a nonce which makes the passed block header hash
@@ -126,6 +127,12 @@ func createCoinbaseTx(coinbaseScript []byte, nextBlockHeight int32,
 			tx.AddTxOut(&mineTo[i])
 		}
 	}
+
+	if tx.SerializeSize() < blockchain.MinTransactionSize {
+		tx.TxIn[0].SignatureScript = append(tx.TxIn[0].SignatureScript,
+			make([]byte, blockchain.MinTransactionSize-tx.SerializeSize())...)
+	}
+
 	return bchutil.NewTx(tx), nil
 }
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gcash/bchd/addrmgr"
 	"io"
 	"io/ioutil"
 	"math"
@@ -28,6 +27,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/gcash/bchd/addrmgr"
 
 	"github.com/btcsuite/websocket"
 	"github.com/gcash/bchd/bchec"


### PR DESCRIPTION
This PR makes a few changes:

1. Whenever we create a coinbase transaction in tests we now make sure it is at least 100 bytes and pad it if necessary.

2.  Fixed `UpdateExtraNonce` so that it also pads the input correctly. Since it mutates the coinbase transaction and doesn't actually build a new coinbase the old code didn't do the right thing. Fortunately this is only used in cpu mining. =)

3. Fix block validations so invalid blocks don't get accepted through submitBlock!

CPU mined this block to test out the new code:

```
2020-05-02 23:26:16.920 [INF] MINR: Block submitted via CPU miner accepted (hash 0000000058b317f8fb152a8e24c46988baf22cab95c432201535d521a54855c1, amount 0.78126 BCH)
```