### PR TITLE
fix deprecated ws package and add no tls example

### DIFF
--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -1353,11 +1353,19 @@ var password = "yourpassword";
 // for the certificate to properly validate.
 var ws = new WebSocket('wss://127.0.0.1:8334/ws', {
   headers: {
-    'Authorization': 'Basic '+new Buffer(user+':'+password).toString('base64')
+    'Authorization': 'Basic '+new Buffer.from(user+':'+password).toString('base64')
   },
   cert: cert,
   ca: [cert]
 });
+
+// if no tls
+//var ws = new WebSocket('ws://127.0.0.1:8334/ws', {
+//  headers: {
+//    'Authorization': 'Basic '+new Buffer.from(user+':'+password).toString('base64')
+//  }
+//});
+
 ws.on('open', function() {
     console.log('CONNECTED');
     // Send a JSON-RPC command to be notified when blocks are connected and


### PR DESCRIPTION
**ws package error**
node version : 10.19.0
package manager : npm
OS : macOS
```
(node:55432) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
ERROR:Error: connect ECONNREFUSED 127.0.0.1:8334
DISCONNECTED
```
ref : https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues