### PR TITLE
Raise MaxCFilterDataSize to 2 MiB

### DIFF
--- a/wire/msgcfilter.go
+++ b/wire/msgcfilter.go
@@ -21,8 +21,8 @@ const (
 
 const (
 	// MaxCFilterDataSize is the maximum byte size of a committed filter.
-	// The maximum size is currently defined as 256KiB.
-	MaxCFilterDataSize = 256 * 1024
+	// The maximum size is currently defined as 2MiB.
+	MaxCFilterDataSize = 2 * 1024 * 1024
 )
 
 // MsgCFilter implements the Message interface and represents a bitcoin cfilter


### PR DESCRIPTION
cfilters for blocks near 32 MB can greatly exceed the previous limit.

2 MiB was chosen because it is large enough to relay outlier cfilters
seen on testnet such as 1685010 bytes for block 1326440.

This addresses #378