### PR TITLE
Add more proto documentation

### DIFF
--- a/bchrpc/bchrpc.proto
+++ b/bchrpc/bchrpc.proto
@@ -82,7 +82,8 @@ service bchrpc {
     rpc SubmitTransaction(SubmitTransactionRequest) returns (SubmitTransactionResponse) {}
 
     // SubscribeTransactions creates subscription to all relevant transactions based on 
-    // the subscription filter.
+    // the subscription filter.  The parameters to filter transactions on can be
+    // updated by sending new SubscribeTransactionsRequest objects on the stream.
     //
     // This RPC does not use bidirectional streams and therefore can be used
     // with grpc-web. You will need to close and reopen the stream whenever
@@ -92,11 +93,11 @@ service bchrpc {
     // **Requires TxIndex to receive input metadata**
     rpc SubscribeTransactions(SubscribeTransactionsRequest) returns (stream TransactionNotification) {}
 
-    // Subscribe to relevant transactions based on the subscription requests.
-    // The parameters to filter transactions on can be updated by sending new
-    // SubscribeTransactionsRequest objects on the stream.
+    // SubscribeTransactionStream subscribes to relevant transactions based on
+    // the subscription requests. The parameters to filter transactions on can
+    // be updated by sending new SubscribeTransactionsRequest objects on the stream.
     //
-    // Because this RPC is using bi-directional streaming it cannot be used with
+    // NOTE: Because this RPC is using bi-directional streaming it cannot be used with
     // grpc-web.
     //
     // **Requires TxIndex to receive input metadata**

--- a/bchrpc/bchrpc.proto
+++ b/bchrpc/bchrpc.proto
@@ -56,23 +56,23 @@ service bchrpc {
     // **Requires AddressIndex**
     rpc GetAddressTransactions(GetAddressTransactionsRequest) returns (GetAddressTransactionsResponse) {}
 
-    // GetRawAddressTransactions the serialized raw transactions for 
+    // GetRawAddressTransactions the serialized raw transactions for
     // the given address. Offers offset, limit, and from block options.
     //
     // **Requires AddressIndex**
     rpc GetRawAddressTransactions(GetRawAddressTransactionsRequest) returns (GetRawAddressTransactionsResponse) {}
 
-    // GetAddressUnspentOutputs returns all the unspent transaction outputs 
+    // GetAddressUnspentOutputs returns all the unspent transaction outputs
     // for the given address.
     //
     // **Requires AddressIndex**
     rpc GetAddressUnspentOutputs(GetAddressUnspentOutputsRequest) returns (GetAddressUnspentOutputsResponse) {}
 
-    // GetUnspentOutput takes an unspent output in the utxo set and returns 
+    // GetUnspentOutput takes an unspent output in the utxo set and returns
     // the utxo metadata or not found.
     rpc GetUnspentOutput(GetUnspentOutputRequest) returns (GetUnspentOutputResponse) {}
 
-    // GetMerkleProof returns a Merkle (SPV) proof for a specific transaction 
+    // GetMerkleProof returns a Merkle (SPV) proof for a specific transaction
     // in the provided block.
     //
     // **Requires TxIndex***
@@ -81,7 +81,7 @@ service bchrpc {
     // SubmitTransaction broadcasts a transaction to all connected peers.
     rpc SubmitTransaction(SubmitTransactionRequest) returns (SubmitTransactionResponse) {}
 
-    // SubscribeTransactions creates subscription to all relevant transactions based on 
+    // SubscribeTransactions creates subscription to all relevant transactions based on
     // the subscription filter.  The parameters to filter transactions on can be
     // updated by sending new SubscribeTransactionsRequest objects on the stream.
     //
@@ -115,12 +115,12 @@ message GetMempoolInfoRequest {}
 message GetMempoolInfoResponse {
     // The count of transactions in the mempool
     uint32 size = 1;
-    // The size in bytes of all transactions in the mempool 
+    // The size in bytes of all transactions in the mempool
     uint32 bytes = 2;
 }
 
 message GetMempoolRequest {
-    // When `full_transactions` is true, full transaction data is provided 
+    // When `full_transactions` is true, full transaction data is provided
     // instead of just transaction hashes. Default is false.
     bool full_transactions = 1;
 }
@@ -135,7 +135,7 @@ message GetMempoolResponse {
             Transaction transaction = 2;
         }
     }
-    
+
     // List of unconfirmed transactions.
     repeated TransactionData transaction_data = 1;
 }
@@ -145,7 +145,7 @@ message GetBlockchainInfoResponse {
 
     // Bitcoin network types
     enum BitcoinNet {
-        
+
         // Live public network with monetary value.
         MAINNET  = 0;
         // An isolated environment for automated testing.
@@ -171,7 +171,7 @@ message GetBlockchainInfoResponse {
     int64 median_time = 5;
     // When `tx_index` is true, the node has full transaction index enabled.
     bool tx_index = 6;
-    // When `addr_index` is true, the node has address index enabled and may 
+    // When `addr_index` is true, the node has address index enabled and may
     // be used with call related by address.
     bool addr_index =7;
 }
@@ -180,7 +180,7 @@ message GetBlockInfoRequest {
     oneof hash_or_height {
         // The block hash as a byte array or base64 encoded string, little-endian.
         bytes hash = 1;
-        // The block number
+        // The block number.
         int32 height = 2;
     }
 }
@@ -196,7 +196,7 @@ message GetBlockRequest {
         // The block number.
         int32 height = 2;
     }
-    // When `full_transactions` is true, full transactions are returned 
+    // When `full_transactions` is true, full transactions are returned
     // instead of just hashes. Default is false.
     bool full_transactions = 3;
 }
@@ -228,19 +228,19 @@ message GetBlockFilterRequest {
 }
 
 message GetBlockFilterResponse {
-    // A compact filter matching input outpoints and public key scripts contained 
+    // A compact filter matching input outpoints and public key scripts contained
     // in a block (encoded according to BIP158).
     bytes filter = 1;
 }
 
 // Request headers using a list of known block hashes.
 message GetHeadersRequest {
-    // A list of block hashes known to the client (most recent first) which 
+    // A list of block hashes known to the client (most recent first) which
     // is exponentially  sparser toward the genesis block (0).
-    // Common practice is to include all of the last 10 blocks, and then 
+    // Common practice is to include all of the last 10 blocks, and then
     // 9 blocks for each order of ten thereafter.
     repeated bytes block_locator_hashes = 1;
-    // hash of the latest desired block header; only blocks occurring before 
+    // hash of the latest desired block header; only blocks occurring before
     // the stop will be returned.
     bytes stop_hash = 2;
 }
@@ -272,18 +272,18 @@ message GetRawTransactionResponse {
 // Get marshaled transactions related to a specific address.
 //
 // RECOMMENDED:
-// Parameters have been provided to query without creating 
+// Parameters have been provided to query without creating
 //   performance issues on the node or client.
 //
 // - The number of transactions to skip and fetch allow for iterating
 //       over a large set of transactions, if necessary.
 //
-// - A starting block parameter (either `hash` or `height`) 
+// - A starting block parameter (either `hash` or `height`)
 //       may then be used to filter results to those occurring
 //       after a certain time.
 //
-// This approach will reduce network traffic and response processing 
-//   for the client, as well as reduce workload on the node. 
+// This approach will reduce network traffic and response processing
+//   for the client, as well as reduce workload on the node.
 message GetAddressTransactionsRequest {
 
     // The address to query transactions, in lowercase cashaddr format.
@@ -298,10 +298,10 @@ message GetAddressTransactionsRequest {
 
 
     oneof start_block {
-        // Recommended. Only get transactions after (or within) a 
+        // Recommended. Only get transactions after (or within) a
         // starting block identified by hash.
         bytes hash = 4;
-        // Recommended. Only get transactions after (or within) a 
+        // Recommended. Only get transactions after (or within) a
         // starting block identified by block number.
         int32 height = 5;
     }
@@ -317,18 +317,18 @@ message GetAddressTransactionsResponse {
 // Get encoded transactions related to a specific address.
 //
 // RECOMMENDED:
-// Parameters have been provided to query without creating 
+// Parameters have been provided to query without creating
 //   performance issues on the node or client.
 //
 // - The number of transactions to skip and fetch allow for iterating
 //       over a large set of transactions, if necessary.
 //
-// - A starting block parameter (either `hash` or `height`) 
+// - A starting block parameter (either `hash` or `height`)
 //       may then be used to filter results to those occurring
 //       after a certain time.
 //
-// This approach will reduce network traffic and response processing 
-//   for the client, as well as reduce workload on the node. 
+// This approach will reduce network traffic and response processing
+//   for the client, as well as reduce workload on the node.
 message GetRawAddressTransactionsRequest {
 
     // The address to query transactions, in lowercase cashaddr format.
@@ -342,10 +342,10 @@ message GetRawAddressTransactionsRequest {
     uint32 nb_fetch = 3;
 
     oneof start_block {
-        // Recommended. Only return transactions after some starting block 
+        // Recommended. Only return transactions after some starting block
         // identified by hash.
         bytes hash = 4;
-        // Recommended. Only return transactions after some starting block 
+        // Recommended. Only return transactions after some starting block
         // identified by block number.
         int32 height = 5;
     }
@@ -361,7 +361,7 @@ message GetAddressUnspentOutputsRequest {
     // The address to query transactions, in lowercase cashaddr format.
     // The network identifiaer is optional (i.e. "cashaddress:").
     string address = 1;
-    // When `include_mempool` is true, unconfirmed transactions from mempool 
+    // When `include_mempool` is true, unconfirmed transactions from mempool
     // are returned. Default is false.
     bool include_mempool = 2;
 }
@@ -375,7 +375,7 @@ message GetUnspentOutputRequest {
     bytes hash = 1;
     // The number of the output, starting from zero.
     uint32 index = 2;
-    // When include_mempool is true, unconfirmed transactions from mempool 
+    // When include_mempool is true, unconfirmed transactions from mempool
     // are returned. Default is false.
     bool include_mempool = 3;
 }
@@ -387,7 +387,7 @@ message GetUnspentOutputResponse {
     bytes pubkey_script = 2;
     // Amount in satoshi.
     int64 value = 3;
-    // When is_coinbase is true, the transaction was the first in a block, 
+    // When is_coinbase is true, the transaction was the first in a block,
     // created by a miner, and used to pay the block reward
     bool is_coinbase = 4;
     // The index number of the block containing the transaction creating the output.
@@ -401,12 +401,12 @@ message GetMerkleProofRequest {
 message GetMerkleProofResponse {
     // Block header information for the corresponding transaction
     BlockInfo block = 1;
-    // A list containing the transaction hash, the adjacent leaf transaction hash 
+    // A list containing the transaction hash, the adjacent leaf transaction hash
     // and the hashes of the highest nodes in the merkle tree not built with the transaction.
     // Proof hashes are ordered following transaction order, or left to right on the merkle tree
     repeated bytes hashes = 2;
     // Binary representing the location of the matching transaction in the full merkle tree,
-    // starting with the root (`1`) at position/level 0, where `1` corresponds 
+    // starting with the root (`1`) at position/level 0, where `1` corresponds
     // to a left branch and `01` is a right branch.
     bytes flags = 3;
 }
@@ -435,8 +435,8 @@ message SubscribeTransactionsRequest {
     // This notification is sent in addition to any requested mempool notifications.
     bool include_in_block = 4;
 
-    // When serialize_tx is true, transactions are serialized using 
-    // bitcoin protocol encoding. Default is false, transaction will be Marshaled 
+    // When serialize_tx is true, transactions are serialized using
+    // bitcoin protocol encoding. Default is false, transaction will be Marshaled
     // (see `Transaction`, `MempoolTransaction` and `TransactionNotification`)
     bool serialize_tx = 5;
 }
@@ -465,13 +465,13 @@ message SubscribeBlocksRequest {
     // Default is false, block metadata is sent. See `BlockInfo`.
     bool full_block = 1;
 
-    // When full_transactions is true, provide full transaction info 
+    // When full_transactions is true, provide full transaction info
     // for a marshaled block.
-    // Default is false, only the transaction hashes are included for 
+    // Default is false, only the transaction hashes are included for
     // a marshaled block. See `TransactionData`.
     bool full_transactions = 2;
 
-    // When serialize_block is true, blocks are serialized using bitcoin protocol encoding. 
+    // When serialize_block is true, blocks are serialized using bitcoin protocol encoding.
     // Default is false, block will be Marshaled (see `BlockInfo` and `BlockNotification`)
     bool serialize_block = 3;
 }
@@ -493,7 +493,7 @@ message BlockNotification {
     oneof block {
         // Marshaled block header data, as well as metadata stored by the node.
         BlockInfo block_info = 2;
-        // A Block 
+        // A Block.
         Block marshaled_block = 3;
         // Binary block, serialized using bitcoin protocol encoding.
         bytes serialized_block = 4;
@@ -501,7 +501,7 @@ message BlockNotification {
 }
 
 message TransactionNotification {
-    
+
     // State of the transaction acceptance.
     enum Type {
         // A transaction in mempool.
@@ -525,11 +525,11 @@ message TransactionNotification {
 
 // DATA MESSAGES
 
-// Metadata for identifying and validating a block 
+// Metadata for identifying and validating a block
 message BlockInfo {
 
     // Identification.
-    
+
     // The double sha256 hash of the six header fields in the first 80 bytes
     // of the block, when encoded according the bitcoin protocol.
     // sha256(sha256(encoded_header))
@@ -554,7 +554,7 @@ message BlockInfo {
     uint32 nonce = 8;
 
     // Metadata.
-    
+
     // Number of blocks in a chain, including the block itself upon creation.
     int32 confirmations = 9;
     // Difficulty target at time of creation.
@@ -593,13 +593,13 @@ message Transaction {
         }
         // The number of the input, starting from zero.
         uint32 index = 1;
-        
+
         // The related outpoint.
         Outpoint outpoint = 2;
-        // An unlocking script asserting a transaction is permitted to spend 
+        // An unlocking script asserting a transaction is permitted to spend
         // the Outpoint (UTXO)
         bytes signature_script = 3;
-        // As of BIP-68, the sequence number is interpreted as a relative 
+        // As of BIP-68, the sequence number is interpreted as a relative
         // lock-time for the input.
         uint32 sequence = 4;
         // Amount in satoshi.
@@ -630,11 +630,11 @@ message Transaction {
     bytes hash = 1;
     // The version of the transaction format.
     int32 version = 2;
-    // List of inputs 
+    // List of inputs.
     repeated Input inputs = 3;
     // List of outputs.
     repeated Output outputs = 4;
-    // The block height or timestamp after which this transaction is allowed. 
+    // The block height or timestamp after which this transaction is allowed.
     // If value is greater than 500 million, it is assumed to be an epoch timestamp,
     // otherwise it is treated as a block-height. Default is zero, or lock.
     uint32 lock_time = 5;
@@ -675,9 +675,9 @@ message UnspentOutput {
     Transaction.Input.Outpoint outpoint = 1;
     // The public key script used to pay coins.
     bytes pubkey_script = 2;
-    // The amount in satoshis 
+    // The amount in satoshis
     int64 value = 3;
-    // When is_coinbase is true, the output is the first in the block, 
+    // When is_coinbase is true, the output is the first in the block,
     // a generation transaction, the result of mining.
     bool is_coinbase = 4;
     // The block number containing the UXTO.
@@ -696,7 +696,7 @@ message TransactionFilter {
     //TODO: Are these extra filters for data elements relevant?
     // - scriptPubkey
     // if so...
-    // Filter by data contained in OP_DATA_1 to OP_PUSHDATA4 in 
+    // Filter by data contained in OP_DATA_1 to OP_PUSHDATA4 in
     // the public key output script
 
     // Subscribe/Unsubscribe to everything. Other filters

--- a/bchrpc/bchrpc.proto
+++ b/bchrpc/bchrpc.proto
@@ -56,21 +56,24 @@ service bchrpc {
     // **Requires AddressIndex**
     rpc GetAddressTransactions(GetAddressTransactionsRequest) returns (GetAddressTransactionsResponse) {}
 
-    // GetRawAddressTransactions the serialized raw transactions for the given address. Offers offset,
-    // limit, and from block options.
+    // GetRawAddressTransactions the serialized raw transactions for 
+    // the given address. Offers offset, limit, and from block options.
     //
     // **Requires AddressIndex**
     rpc GetRawAddressTransactions(GetRawAddressTransactionsRequest) returns (GetRawAddressTransactionsResponse) {}
 
-    // GetAddressUnspentOutputs returns all the unspent transaction outputs for the given address.
+    // GetAddressUnspentOutputs returns all the unspent transaction outputs 
+    // for the given address.
     //
     // **Requires AddressIndex**
     rpc GetAddressUnspentOutputs(GetAddressUnspentOutputsRequest) returns (GetAddressUnspentOutputsResponse) {}
 
-    // GetUnspentOutput takes an unspent output in the utxo set and returns the utxo metadata or not found.
+    // GetUnspentOutput takes an unspent output in the utxo set and returns 
+    // the utxo metadata or not found.
     rpc GetUnspentOutput(GetUnspentOutputRequest) returns (GetUnspentOutputResponse) {}
 
-    // GetMerkleProof returns a Merkle (SPV) proof for a specific transaction in the provided block.
+    // GetMerkleProof returns a Merkle (SPV) proof for a specific transaction 
+    // in the provided block.
     //
     // **Requires TxIndex***
     rpc GetMerkleProof(GetMerkleProofRequest) returns (GetMerkleProofResponse) {}
@@ -167,7 +170,8 @@ message GetBlockchainInfoResponse {
     int64 median_time = 5;
     // When `tx_index` is true, the node has full transaction index enabled.
     bool tx_index = 6;
-    // When `addr_index` is true, the node has address index enabled and may be used with call related by address.
+    // When `addr_index` is true, the node has address index enabled and may 
+    // be used with call related by address.
     bool addr_index =7;
 }
 
@@ -191,7 +195,8 @@ message GetBlockRequest {
         // The block number.
         int32 height = 2;
     }
-    // When `full_transactions` is true, full transactions are returned instead of just hashes. Default is false.
+    // When `full_transactions` is true, full transactions are returned 
+    // instead of just hashes. Default is false.
     bool full_transactions = 3;
 }
 message GetBlockResponse {
@@ -222,17 +227,20 @@ message GetBlockFilterRequest {
 }
 
 message GetBlockFilterResponse {
-    // A compact filter matching input outpoints and public key scripts contained in a block (encoded according to BIP158).
+    // A compact filter matching input outpoints and public key scripts contained 
+    // in a block (encoded according to BIP158).
     bytes filter = 1;
 }
 
 // Request headers using a list of known block hashes.
 message GetHeadersRequest {
-    // A list of block hashes known to the client (most recent first) which is exponentially 
-    // sparser toward the genesis block (0).
-    // Common practice is to include all of the last 10 blocks, and then 9 blocks for each order of ten thereafter.
+    // A list of block hashes known to the client (most recent first) which 
+    // is exponentially  sparser toward the genesis block (0).
+    // Common practice is to include all of the last 10 blocks, and then 
+    // 9 blocks for each order of ten thereafter.
     repeated bytes block_locator_hashes = 1;
-    // hash of the latest desired block header; only blocks occurring before the stop will be returned.
+    // hash of the latest desired block header; only blocks occurring before 
+    // the stop will be returned.
     bytes stop_hash = 2;
 }
 message GetHeadersResponse {
@@ -289,9 +297,11 @@ message GetAddressTransactionsRequest {
 
 
     oneof start_block {
-        // Recommended. Only get transactions after (or within) a starting block identified by hash.
+        // Recommended. Only get transactions after (or within) a 
+        // starting block identified by hash.
         bytes hash = 4;
-        // Recommended. Only get transactions after (or within) a starting block identified by block number.
+        // Recommended. Only get transactions after (or within) a 
+        // starting block identified by block number.
         int32 height = 5;
     }
 }
@@ -331,9 +341,11 @@ message GetRawAddressTransactionsRequest {
     uint32 nb_fetch = 3;
 
     oneof start_block {
-        // Recommended. Only return transactions after some starting block identified by hash.
+        // Recommended. Only return transactions after some starting block 
+        // identified by hash.
         bytes hash = 4;
-        // Recommended. Only return transactions after some starting block identified by block number.
+        // Recommended. Only return transactions after some starting block 
+        // identified by block number.
         int32 height = 5;
     }
 }
@@ -348,7 +360,8 @@ message GetAddressUnspentOutputsRequest {
     // The address to query transactions, in lowercase cashaddr format.
     // The network identifiaer is optional (i.e. "cashaddress:").
     string address = 1;
-    // When `include_mempool` is true, unconfirmed transactions from mempool are returned. Default is false.
+    // When `include_mempool` is true, unconfirmed transactions from mempool 
+    // are returned. Default is false.
     bool include_mempool = 2;
 }
 message GetAddressUnspentOutputsResponse {
@@ -361,7 +374,8 @@ message GetUnspentOutputRequest {
     bytes hash = 1;
     // The number of the output, starting from zero.
     uint32 index = 2;
-    // When include_mempool is true, unconfirmed transactions from mempool are returned. Default is false.
+    // When include_mempool is true, unconfirmed transactions from mempool 
+    // are returned. Default is false.
     bool include_mempool = 3;
 }
 message GetUnspentOutputResponse {
@@ -372,7 +386,8 @@ message GetUnspentOutputResponse {
     bytes pubkey_script = 2;
     // Amount in satoshi.
     int64 value = 3;
-    // When is_coinbase is true, the transaction was the first in a block, created by a miner, and used to pay the block reward
+    // When is_coinbase is true, the transaction was the first in a block, 
+    // created by a miner, and used to pay the block reward
     bool is_coinbase = 4;
     // The index number of the block containing the transaction creating the output.
     int32 block_height = 5;
@@ -390,7 +405,8 @@ message GetMerkleProofResponse {
     // Proof hashes are ordered following transaction order, or left to right on the merkle tree
     repeated bytes hashes = 2;
     // Binary representing the location of the matching transaction in the full merkle tree,
-    // starting with the root (`1`) at position/level 0, where `1` corresponds to a left branch and `01` is a right branch.
+    // starting with the root (`1`) at position/level 0, where `1` corresponds 
+    // to a left branch and `01` is a right branch.
     bytes flags = 3;
 }
 
@@ -418,8 +434,9 @@ message SubscribeTransactionsRequest {
     // This notification is sent in addition to any requested mempool notifications.
     bool include_in_block = 4;
 
-    // When serialize_tx is true, transactions are serialized using bitcoin protocol encoding. 
-    // Default is false, transaction will be Marshaled (see `Transaction`, `MempoolTransaction` and `TransactionNotification`)
+    // When serialize_tx is true, transactions are serialized using 
+    // bitcoin protocol encoding. Default is false, transaction will be Marshaled 
+    // (see `Transaction`, `MempoolTransaction` and `TransactionNotification`)
     bool serialize_tx = 5;
 }
 
@@ -447,8 +464,10 @@ message SubscribeBlocksRequest {
     // Default is false, block metadata is sent. See `BlockInfo`.
     bool full_block = 1;
 
-    // When full_transactions is true, provide full transaction info for a marshaled block.
-    // Default is false, only the transaction hashes are included for a marshaled block. See `TransactionData`.
+    // When full_transactions is true, provide full transaction info 
+    // for a marshaled block.
+    // Default is false, only the transaction hashes are included for 
+    // a marshaled block. See `TransactionData`.
     bool full_transactions = 2;
 
     // When serialize_block is true, blocks are serialized using bitcoin protocol encoding. 
@@ -576,9 +595,11 @@ message Transaction {
         
         // The related outpoint.
         Outpoint outpoint = 2;
-        // An unlocking script asserting a transaction is permitted to spend the Outpoint (UTXO)
+        // An unlocking script asserting a transaction is permitted to spend 
+        // the Outpoint (UTXO)
         bytes signature_script = 3;
-        // As of BIP-68, the sequence number is interpreted as a relative lock-time for the input.
+        // As of BIP-68, the sequence number is interpreted as a relative 
+        // lock-time for the input.
         uint32 sequence = 4;
         // Amount in satoshi.
         int64 value = 5;
@@ -623,7 +644,8 @@ message Transaction {
     int32 size = 8;
     // When the transaction was included in a block, in epoch time.
     int64 timestamp = 9;
-    // Number of blocks including proof of the transaction, including the block it appeared.
+    // Number of blocks including proof of the transaction, including
+    // the block it appeared.
     int32 confirmations = 10;
     // Number of the block containing the transaction.
     int32 block_height = 11;
@@ -654,7 +676,8 @@ message UnspentOutput {
     bytes pubkey_script = 2;
     // The amount in satoshis 
     int64 value = 3;
-    // When is_coinbase is true, the output is the first in the block, a generation transaction, the result of mining.
+    // When is_coinbase is true, the output is the first in the block, 
+    // a generation transaction, the result of mining.
     bool is_coinbase = 4;
     // The block number containing the UXTO.
     int32 block_height = 5;
@@ -672,7 +695,8 @@ message TransactionFilter {
     //TODO: Are these extra filters for data elements relevant?
     // - scriptPubkey
     // if so...
-    // Filter by data contained in OP_DATA_1 to OP_PUSHDATA4 in the public key output script
+    // Filter by data contained in OP_DATA_1 to OP_PUSHDATA4 in 
+    // the public key output script
 
     // Subscribe/Unsubscribe to everything. Other filters
     // will be ignored.

--- a/bchrpc/bchrpc.proto
+++ b/bchrpc/bchrpc.proto
@@ -7,80 +7,82 @@ package pb;
 // unauthenticated.
 service bchrpc {
 
-    // Get info about the mempool.
+    // GetMempoolInfo returns the state of the current mempool.
     rpc GetMempoolInfo(GetMempoolInfoRequest) returns (GetMempoolInfoResponse) {}
 
-    // Returns information about all of the transactions currently in the memory pool.
+    // GetMempool returns information about all transactions currently in the memory pool.
     // Offers an option to return full transactions or just transactions hashes.
     rpc GetMempool(GetMempoolRequest) returns (GetMempoolResponse) {}
 
-    // GetBlockchainInfo info about the blockchain including the most recent
+    // GetBlockchainInfo returns data about the blockchain including the most recent
     // block hash and height.
     rpc GetBlockchainInfo(GetBlockchainInfoRequest) returns (GetBlockchainInfoResponse) {}
 
-    // Get info about the given block.
+    // GetBlockInfo returns metadata and info for a specified block.
     rpc GetBlockInfo(GetBlockInfoRequest)returns (GetBlockInfoResponse) {}
 
-    // Get a block.
+    // GetBlock returns detailed data for a block.
     rpc GetBlock(GetBlockRequest) returns (GetBlockResponse) {}
 
-    // Get a serialized block.
+    // GetRawBlock returns a block in a serialized format.
     rpc GetRawBlock(GetRawBlockRequest) returns (GetRawBlockResponse) {}
 
-    // Get a block filter.
+    // GetBlockFilter returns the compact filter (cf) of a block as a Golomb-Rice encoded set.
     //
     // **Requires CfIndex**
     rpc GetBlockFilter(GetBlockFilterRequest) returns (GetBlockFilterResponse) {}
 
-    // This RPC sends a block locator object to the server and the server responds with
+    // GetHeaders takes a block locator object and returns
     // a batch of no more than 2000 headers. Upon parsing the block locator, if the server
     // concludes there has been a fork, it will send headers starting at the fork point,
     // or genesis if no blocks in the locator are in the best chain. If the locator is
     // already at the tip no headers will be returned.
+    // see: bchd/bchrpc/documentation/wallet_operation.md
     rpc GetHeaders(GetHeadersRequest) returns (GetHeadersResponse) {}
 
-    // Get a transaction given its hash.
+    // GetTransaction returns a transaction given a transaction hash.
     //
     // **Requires TxIndex**
     rpc GetTransaction(GetTransactionRequest) returns (GetTransactionResponse) {}
 
-    // Get a serialized transaction given its hash.
+    // GetRawTransaction returns a serialized transaction given a transaction hash.
     //
     // **Requires TxIndex**
     rpc GetRawTransaction(GetRawTransactionRequest) returns (GetRawTransactionResponse) {}
 
-    // Returns the transactions for the given address. Offers offset,
+    // GetAddressTransactions returns the transactions for the given address. Offers offset,
     // limit, and from block options.
     //
     // **Requires AddressIndex**
     rpc GetAddressTransactions(GetAddressTransactionsRequest) returns (GetAddressTransactionsResponse) {}
 
-    // Returns the raw transactions for the given address. Offers offset,
+    // GetRawAddressTransactions the serialized raw transactions for the given address. Offers offset,
     // limit, and from block options.
     //
     // **Requires AddressIndex**
     rpc GetRawAddressTransactions(GetRawAddressTransactionsRequest) returns (GetRawAddressTransactionsResponse) {}
 
-    // Returns all the unspent transaction outputs for the given address.
+    // GetAddressUnspentOutputs returns all the unspent transaction outputs for the given address.
     //
     // **Requires AddressIndex**
     rpc GetAddressUnspentOutputs(GetAddressUnspentOutputsRequest) returns (GetAddressUnspentOutputsResponse) {}
 
-    // Looks up the unspent output in the utxo set and returns the utxo metadata or not found.
+    // GetUnspentOutput takes an unspent output in the utxo set and returns the utxo metadata or not found.
     rpc GetUnspentOutput(GetUnspentOutputRequest) returns (GetUnspentOutputResponse) {}
 
-    // Returns a merkle (SPV) proof that the given transaction is in the provided block.
+    // GetMerkleProof returns a Merkle (SPV) proof for a specific transaction in the provided block.
     //
     // **Requires TxIndex***
     rpc GetMerkleProof(GetMerkleProofRequest) returns (GetMerkleProofResponse) {}
 
-    // Submit a transaction to all connected peers.
+    // SubmitTransaction broadcasts a transaction to all connected peers.
     rpc SubmitTransaction(SubmitTransactionRequest) returns (SubmitTransactionResponse) {}
 
-    // Subscribe to relevant transactions based on the subscription requests.
+    // SubscribeTransactions creates subscription to all relevant transactions based on 
+    // the subscription filter.
     //
-    // This RPC does not use bi-directional streams and therefore can be used
-    // with grpc-web. You will need to close and re-open the stream whenever
+    // This RPC does not use bidirectional streams and therefore can be used
+    // with grpc-web. You will need to close and reopen the stream whenever
     // you want to update the addresses. If you are not using grpc-web
     // then SubscribeTransactionStream is more appropriate.
     //
@@ -97,8 +99,8 @@ service bchrpc {
     // **Requires TxIndex to receive input metadata**
     rpc SubscribeTransactionStream(stream SubscribeTransactionsRequest) returns (stream TransactionNotification) {}
 
-    // Subscribe to notifications of new blocks being connected to the blockchain
-    // or blocks being disconnected.
+    // SubscribeBlocks creates a subscription for notifications of new blocks being
+    // connected to the blockchain or blocks being disconnected.
     rpc SubscribeBlocks(SubscribeBlocksRequest) returns (stream BlockNotification) {}
 }
 
@@ -107,193 +109,308 @@ service bchrpc {
 
 message GetMempoolInfoRequest {}
 message GetMempoolInfoResponse {
+    // The count of transactions in the mempool
     uint32 size = 1;
+    // The size in bytes of all transactions in the mempool 
     uint32 bytes = 2;
 }
 
 message GetMempoolRequest {
-    // Provide full transaction info instead of only the hashes.
+    // When `full_transactions` is true, full transaction data is provided 
+    // instead of just transaction hashes. Default is false.
     bool full_transactions = 1;
 }
+
 message GetMempoolResponse {
     message TransactionData {
         // Either one of the two following is provided, depending on the request.
         oneof txids_or_txs {
+            // The transaction hash
             bytes transaction_hash = 1;
+            // The transaction data
             Transaction transaction = 2;
         }
     }
-
+    
+    // List of unconfirmed transactions.
     repeated TransactionData transaction_data = 1;
 }
 
 message GetBlockchainInfoRequest {}
 message GetBlockchainInfoResponse {
+
+    // Bitcoin network types
     enum BitcoinNet {
+        
+        // Live public network with monetary value.
         MAINNET  = 0;
+        // An isolated environment for automated testing.
         REGTEST  = 1;
+        // A public environment where monetary value is agreed to be zero,
+        // and some checks for transaction conformity are disabled.
         TESTNET3 = 2;
+        // Private testnets for large scale simulations (or stress testing),
+        // where a specified list of nodes is used, rather than node discovery.
         SIMNET   = 3;
     }
 
+    // Which network the node is operating on.
     BitcoinNet bitcoin_net = 1;
+
+    // The current number of blocks on the longest chain.
     int32 best_height = 2;
+    // The hash of the best (tip) block in the most-work fully-validated chain.
     bytes best_block_hash = 3;
+    // Threshold for adding new blocks.
     double difficulty = 4;
+    // Median time of the last 11 blocks.
     int64 median_time = 5;
+    // When `tx_index` is true, the node has full transaction index enabled.
     bool tx_index = 6;
+    // When `addr_index` is true, the node has address index enabled and may be used with call related by address.
     bool addr_index =7;
 }
 
 message GetBlockInfoRequest {
     oneof hash_or_height {
+        // The block hash as a byte array or base64 encoded string, little-endian.
         bytes hash = 1;
+        // The block number
         int32 height = 2;
     }
 }
 message GetBlockInfoResponse {
+    // Marshaled block header data, as well as metadata.
     BlockInfo info = 1;
 }
 
 message GetBlockRequest {
     oneof hash_or_height {
+        // The block hash as a byte array or base64 encoded string, little-endian.
         bytes hash = 1;
+        // The block number.
         int32 height = 2;
     }
-    // Provide full transaction info instead of only the hashes.
+    // When `full_transactions` is true, full transactions are returned instead of just hashes. Default is false.
     bool full_transactions = 3;
 }
 message GetBlockResponse {
+    // A marshaled block.
     Block block = 1;
 }
 
 message GetRawBlockRequest {
     oneof hash_or_height {
+        // The block hash as a byte array or base64 encoded string, little-endian.
         bytes hash = 1;
+        // The block number.
         int32 height = 2;
     }
 }
 message GetRawBlockResponse {
+    // Raw block data (with header) serialized according the the bitcoin block protocol.
     bytes block = 1;
 }
 
 message GetBlockFilterRequest {
     oneof hash_or_height {
+        // The block hash as a byte array or base64 encoded string, little-endian.
         bytes hash = 1;
+        // The block number.
         int32 height = 2;
     }
 }
+
 message GetBlockFilterResponse {
+    // A compact filter matching input outpoints and public key scripts contained in a block (encoded according to BIP158).
     bytes filter = 1;
 }
 
+// Request headers using a list of known block hashes.
 message GetHeadersRequest {
+    // A list of block hashes known to the client (most recent first) which is exponentially 
+    // sparser toward the genesis block (0).
+    // Common practice is to include all of the last 10 blocks, and then 9 blocks for each order of ten thereafter.
     repeated bytes block_locator_hashes = 1;
+    // hash of the latest desired block header; only blocks occurring before the stop will be returned.
     bytes stop_hash = 2;
 }
 message GetHeadersResponse {
+    // List of block headers.
     repeated BlockInfo headers = 1;
 }
 
+// Get a transaction from a transaction hash.
 message GetTransactionRequest {
+    // A transaction hash.
     bytes hash = 1;
 }
 message GetTransactionResponse {
+    // A marshaled transaction.
     Transaction transaction = 1;
 }
 
+// Get an encoded transaction from a transaction hash.
 message GetRawTransactionRequest {
+    // A transaction hash.
     bytes hash = 1;
 }
 message GetRawTransactionResponse {
+    // Raw transaction in bytes.
     bytes transaction = 1;
 }
 
+// Get marshaled transactions related to a specific address.
+//
+// RECOMMENDED:
+// Parameters have been provided to query without creating 
+//   performance issues on the node or client.
+//
+// - The number of transactions to skip and fetch allow for iterating
+//       over a large set of transactions, if necessary.
+//
+// - A starting block parameter (either `hash` or `height`) 
+//       may then be used to filter results to those occurring
+//       after a certain time.
+//
+// This approach will reduce network traffic and response processing 
+//   for the client, as well as reduce workload on the node. 
 message GetAddressTransactionsRequest {
+
+    // The address to query transactions, in lowercase cashaddr format.
+    // The network prefix is optional (i.e. "cashaddress:").
     string address = 1;
 
-    // Control the number of transactions to be fetched from the blockchain.
-    // These controls only apply to the confirmed transactions. All unconfirmed
-    // ones will be returned always.
+    // The number of confirmed transactions to skip, starting with the oldest first.
+    // Does not affect results of unconfirmed transactions.
     uint32 nb_skip = 2;
+    // Specify the number of transactions to fetch.
     uint32 nb_fetch = 3;
 
-    // If the start block is provided it will only return transactions after this
-    // block. This should be used if possible to save bandwidth.
+
     oneof start_block {
+        // Recommended. Only get transactions after (or within) a starting block identified by hash.
         bytes hash = 4;
+        // Recommended. Only get transactions after (or within) a starting block identified by block number.
         int32 height = 5;
     }
 }
 message GetAddressTransactionsResponse {
+
+    // Transactions that have been included in a block.
     repeated Transaction confirmed_transactions = 1;
+    // Transactions in mempool which have not been included in a block.
     repeated MempoolTransaction unconfirmed_transactions = 2;
 }
 
+// Get encoded transactions related to a specific address.
+//
+// RECOMMENDED:
+// Parameters have been provided to query without creating 
+//   performance issues on the node or client.
+//
+// - The number of transactions to skip and fetch allow for iterating
+//       over a large set of transactions, if necessary.
+//
+// - A starting block parameter (either `hash` or `height`) 
+//       may then be used to filter results to those occurring
+//       after a certain time.
+//
+// This approach will reduce network traffic and response processing 
+//   for the client, as well as reduce workload on the node. 
 message GetRawAddressTransactionsRequest {
+
+    // The address to query transactions, in lowercase cashaddr format.
+    // The network prefix is optional (i.e. "cashaddress:").
     string address = 1;
 
-    // Control the number of transactions to be fetched from the blockchain.
-    // These controls only apply to the confirmed transactions. All unconfirmed
-    // ones will be returned always.
+    // The number of confirmed transactions to skip, starting with the oldest first.
+    // Does not affect results of unconfirmed transactions.
     uint32 nb_skip = 2;
+    // Specify the number of transactions to fetch.
     uint32 nb_fetch = 3;
 
-    // If the start block is provided it will only return transactions after this
-    // block. This should be used if possible to save bandwidth.
     oneof start_block {
+        // Recommended. Only return transactions after some starting block identified by hash.
         bytes hash = 4;
+        // Recommended. Only return transactions after some starting block identified by block number.
         int32 height = 5;
     }
 }
 message GetRawAddressTransactionsResponse {
+    // Transactions that have been included in a block.
     repeated bytes confirmed_transactions = 1;
+    // Transactions in mempool which have not been included in a block.
     repeated bytes unconfirmed_transactions = 2;
 }
 
 message GetAddressUnspentOutputsRequest {
+    // The address to query transactions, in lowercase cashaddr format.
+    // The network identifiaer is optional (i.e. "cashaddress:").
     string address = 1;
+    // When `include_mempool` is true, unconfirmed transactions from mempool are returned. Default is false.
     bool include_mempool = 2;
 }
 message GetAddressUnspentOutputsResponse {
+    // List of unspent outputs.
     repeated UnspentOutput outputs = 1;
 }
 
 message GetUnspentOutputRequest {
+    // The hash of the transaction.
     bytes hash = 1;
+    // The number of the output, starting from zero.
     uint32 index = 2;
+    // When include_mempool is true, unconfirmed transactions from mempool are returned. Default is false.
     bool include_mempool = 3;
 }
 message GetUnspentOutputResponse {
-    Transaction.Input.Outpoint outpoint = 1;
-    bytes pubkey_script = 2;
-    int64 value = 3;
 
+    // A reference to the related input.
+    Transaction.Input.Outpoint outpoint = 1;
+    // Locking script dictating how funds can be spent in the future
+    bytes pubkey_script = 2;
+    // Amount in satoshi.
+    int64 value = 3;
+    // When is_coinbase is true, the transaction was the first in a block, created by a miner, and used to pay the block reward
     bool is_coinbase = 4;
+    // The index number of the block containing the transaction creating the output.
     int32 block_height = 5;
 }
 
 message GetMerkleProofRequest {
+    // A transaction hash.
     bytes transaction_hash = 1;
 }
 message GetMerkleProofResponse {
+    // Block header information for the corresponding transaction
     BlockInfo block = 1;
+    // A list containing the transaction hash, the adjacent leaf transaction hash 
+    // and the hashes of the highest nodes in the merkle tree not built with the transaction.
+    // Proof hashes are ordered following transaction order, or left to right on the merkle tree
     repeated bytes hashes = 2;
+    // Binary representing the location of the matching transaction in the full merkle tree,
+    // starting with the root (`1`) at position/level 0, where `1` corresponds to a left branch and `01` is a right branch.
     bytes flags = 3;
 }
 
 message SubmitTransactionRequest {
+    // The encoded transaction.
     bytes transaction = 1;
 }
 message SubmitTransactionResponse {
     bytes hash = 1;
 }
 
+// Request to subscribe or unsubscribe from a stream of transactions.
 message SubscribeTransactionsRequest {
+
+    // Subscribe to a filter. add items to a filter
     TransactionFilter subscribe = 1;
+    // Unsubscribe to a filter, remove items from a filter
     TransactionFilter unsubscribe = 2;
 
-    // When include_mempool is true, new transactions coming in from the mempool are
+    // When include_mempool is true, new unconfirmed transactions from mempool are
     // included apart from the ones confirmed in a block.
     bool include_mempool = 3;
 
@@ -342,30 +459,45 @@ message SubscribeBlocksRequest {
 
 // NOTIFICATIONS
 
+
 message BlockNotification {
+
+    // State of the block in relation to the chain.
     enum Type {
         CONNECTED = 0;
         DISCONNECTED = 1;
     }
 
+    // Whether the block is connected to the chain.
     Type type = 1;
     oneof block {
+        // Marshaled block header data, as well as metadata stored by the node.
         BlockInfo block_info = 2;
+        // A Block 
         Block marshaled_block = 3;
+        // Binary block, serialized using bitcoin protocol encoding.
         bytes serialized_block = 4;
     }
 }
 
 message TransactionNotification {
+    
+    // State of the transaction acceptance.
     enum Type {
+        // A transaction in mempool.
         UNCONFIRMED = 0;
+        // A transaction in a block.
         CONFIRMED   = 1;
     }
 
+    // Whether or not the transaction has been included in a block.
     Type type = 1;
     oneof transaction {
+        // A transaction included in a block.
         Transaction confirmed_transaction = 2;
+        // A transaction in mempool.
         MempoolTransaction unconfirmed_transaction = 3;
+        // Binary transaction, serialized using bitcoin protocol encoding.
         bytes serialized_transaction = 4;
     }
 }
@@ -373,75 +505,129 @@ message TransactionNotification {
 
 // DATA MESSAGES
 
+// Metadata for identifying and validating a block 
 message BlockInfo {
+
     // Identification.
+    
+    // The double sha256 hash of the six header fields in the first 80 bytes
+    // of the block, when encoded according the bitcoin protocol.
+    // sha256(sha256(encoded_header))
     bytes hash = 1;
+    // The block number, an incremental index for each block mined.
     int32 height = 2;
 
     // Block header data.
+
+    // A version number to track software/protocol upgrades.
     int32 version = 3;
+    // Hash of the previous block
     bytes previous_block = 4;
+    // The root of the Merkle Tree built from all transactions in the block.
     bytes merkle_root = 5;
+    // When mining of the block started, expressed in seconds since 1970-01-01.
     int64 timestamp = 6;
+    // Difficulty in Compressed Target Format.
     uint32 bits = 7;
+    // A random value that was generated during block mining which happened to
+    // result in a computed block hash below the difficulty target at the time.
     uint32 nonce = 8;
 
     // Metadata.
+    
+    // Number of blocks in a chain, including the block itself upon creation.
     int32 confirmations = 9;
+    // Difficulty target at time of creation.
     double difficulty = 10;
+    // Hash of the next block in this chain.
     bytes next_block_hash = 11;
+    // Size of the block in bytes.
     int32 size = 12;
+    // The median block time of the latest 11 block timestamps.
     int64 median_time = 13;
 }
 
 message Block {
     message TransactionData {
-        // Either one of the two following is provided, depending on the request.
         oneof txids_or_txs {
+            // Just the transaction hash.
             bytes transaction_hash = 1;
+            // A marshaled transaction.
             Transaction transaction = 2;
         }
     }
-
+    // Block header data, as well as metadata stored by the node.
     BlockInfo info = 1;
+    // List of transactions or transaction hashes.
     repeated TransactionData transaction_data = 2;
 }
 
 message Transaction {
+
     message Input {
         message Outpoint {
+            // The hash of the transaction containing the output to be spent.
             bytes hash = 1;
+            // The index of specific output on the transaction.
             uint32 index = 2;
         }
-
+        // The number of the input, starting from zero.
         uint32 index = 1;
+        
+        // The related outpoint.
         Outpoint outpoint = 2;
+        // An unlocking script asserting a transaction is permitted to spend the Outpoint (UTXO)
         bytes signature_script = 3;
+        // As of BIP-68, the sequence number is interpreted as a relative lock-time for the input.
         uint32 sequence = 4;
+        // Amount in satoshi.
         int64 value = 5;
+        // The hash of the transaction containing the output to be spent.
         bytes previous_script = 6;
+        // The bitcoin addresses associated with this input.
         string address = 7;
     }
+
     message Output {
+        // The number of the output, starting from zero.
         uint32 index = 1;
+        // The number of satoshis to be transferred.
         int64 value = 2;
+        // The public key script used to pay coins.
         bytes pubkey_script = 3;
+        // The bitcoin addresses associated with this output.
         string address = 4;
+        // The type of script.
         string script_class = 5;
+        // The script expressed in Bitcoin Cash Script.
         string disassembled_script = 6;
     }
 
+    // The double sha256 hash of the encoded transaction.
+    // sha256(sha256(encoded_transaction))
     bytes hash = 1;
+    // The version of the transaction format.
     int32 version = 2;
+    // List of inputs 
     repeated Input inputs = 3;
+    // List of outputs.
     repeated Output outputs = 4;
+    // The block height or timestamp after which this transaction is allowed. 
+    // If value is greater than 500 million, it is assumed to be an epoch timestamp,
+    // otherwise it is treated as a block-height. Default is zero, or lock.
     uint32 lock_time = 5;
 
     // Metadata
+
+    // The size of the transaction in bytes.
     int32 size = 8;
+    // When the transaction was included in a block, in epoch time.
     int64 timestamp = 9;
+    // Number of blocks including proof of the transaction, including the block it appeared.
     int32 confirmations = 10;
+    // Number of the block containing the transaction.
     int32 block_height = 11;
+    // Hash of the block the transaction was recorded in.
     bytes block_hash = 12;
 }
 
@@ -461,23 +647,34 @@ message MempoolTransaction {
 }
 
 message UnspentOutput {
-    Transaction.Input.Outpoint outpoint = 1;
-    bytes pubkey_script = 2;
-    int64 value = 3;
 
+    // A reference to the output given by transaction hash and index.
+    Transaction.Input.Outpoint outpoint = 1;
+    // The public key script used to pay coins.
+    bytes pubkey_script = 2;
+    // The amount in satoshis 
+    int64 value = 3;
+    // When is_coinbase is true, the output is the first in the block, a generation transaction, the result of mining.
     bool is_coinbase = 4;
+    // The block number containing the UXTO.
     int32 block_height = 5;
 }
 
 message TransactionFilter {
+
+    // Filter by address(es)
     repeated string addresses = 1;
+
+    // Filter by output hash and index.
     repeated Transaction.Input.Outpoint outpoints = 2;
     repeated bytes data_elements = 3;
 
-    //TODO: Are these extra filters values relevant?
+    //TODO: Are these extra filters for data elements relevant?
     // - scriptPubkey
+    // if so...
+    // Filter by data contained in OP_DATA_1 to OP_PUSHDATA4 in the public key output script
 
-    // Subscribed/Unsubscribe to everything. Other filters
+    // Subscribe/Unsubscribe to everything. Other filters
     // will be ignored.
     bool all_transactions = 4;
 }

--- a/bchrpc/bchrpc.proto
+++ b/bchrpc/bchrpc.proto
@@ -359,7 +359,7 @@ message GetRawAddressTransactionsResponse {
 
 message GetAddressUnspentOutputsRequest {
     // The address to query transactions, in lowercase cashaddr format.
-    // The network identifiaer is optional (i.e. "cashaddress:").
+    // The network identifier is optional (i.e. "cashaddress:").
     string address = 1;
     // When `include_mempool` is true, unconfirmed transactions from mempool
     // are returned. Default is false.

--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -315,7 +315,7 @@ func (s *GrpcServer) checkReady() bool {
 	return atomic.LoadUint32(&s.ready) != 0
 }
 
-// GetMempoolInfo returns info about the mempool.
+// GetMempoolInfo returns the state of the current mempool.
 func (s *GrpcServer) GetMempoolInfo(ctx context.Context, req *pb.GetMempoolInfoRequest) (*pb.GetMempoolInfoResponse, error) {
 	nBytes := uint32(0)
 	for _, txDesc := range s.txMemPool.TxDescs() {
@@ -400,7 +400,7 @@ func (s *GrpcServer) GetBlockchainInfo(ctx context.Context, req *pb.GetBlockchai
 	return resp, nil
 }
 
-// GetBlockInfo returns info about the given block.
+// GetBlockInfo returns metadata and info for a specified block.
 func (s *GrpcServer) GetBlockInfo(ctx context.Context, req *pb.GetBlockInfoRequest) (*pb.GetBlockInfoResponse, error) {
 	var (
 		block *bchutil.Block
@@ -437,7 +437,7 @@ func (s *GrpcServer) GetBlockInfo(ctx context.Context, req *pb.GetBlockInfoReque
 	return resp, nil
 }
 
-// GetBlock returns a full block.
+// GetBlock returns detailed data for a block.
 func (s *GrpcServer) GetBlock(ctx context.Context, req *pb.GetBlockRequest) (*pb.GetBlockResponse, error) {
 	var (
 		block *bchutil.Block
@@ -516,7 +516,7 @@ func (s *GrpcServer) GetBlock(ctx context.Context, req *pb.GetBlockRequest) (*pb
 	return resp, nil
 }
 
-// GetRawBlock returns a full serialized block.
+// GetRawBlock returns a block in a serialized format.
 func (s *GrpcServer) GetRawBlock(ctx context.Context, req *pb.GetRawBlockRequest) (*pb.GetRawBlockResponse, error) {
 	var (
 		block *bchutil.Block
@@ -545,7 +545,7 @@ func (s *GrpcServer) GetRawBlock(ctx context.Context, req *pb.GetRawBlockRequest
 	return resp, nil
 }
 
-// GetBlockFilter returns a block filter.
+// GetBlockFilter returns the compact filter (cf) of a block as a Golomb-Rice encoded set.
 //
 // **Requires CfIndex**
 func (s *GrpcServer) GetBlockFilter(ctx context.Context, req *pb.GetBlockFilterRequest) (*pb.GetBlockFilterResponse, error) {
@@ -579,11 +579,12 @@ func (s *GrpcServer) GetBlockFilter(ctx context.Context, req *pb.GetBlockFilterR
 	return resp, nil
 }
 
-// GetHeaders sends a block locator object to the server and the server responds with
+// GetHeaders takes a block locator object and returns
 // a batch of no more than 2000 headers. Upon parsing the block locator, if the server
 // concludes there has been a fork, it will send headers starting at the fork point,
 // or genesis if no blocks in the locator are in the best chain. If the locator is
 // already at the tip no headers will be returned.
+// see: bchd/bchrpc/documentation/wallet_operation.md
 func (s *GrpcServer) GetHeaders(ctx context.Context, req *pb.GetHeadersRequest) (*pb.GetHeadersResponse, error) {
 	var (
 		locator blockchain.BlockLocator
@@ -705,7 +706,7 @@ func (s *GrpcServer) GetTransaction(ctx context.Context, req *pb.GetTransactionR
 	return resp, nil
 }
 
-// GetRawTransaction returns a serialized transaction given its hash.
+// GetRawTransaction returns a serialized transaction given a transaction hash.
 //
 // **Requires TxIndex**
 func (s *GrpcServer) GetRawTransaction(ctx context.Context, req *pb.GetRawTransactionRequest) (*pb.GetRawTransactionResponse, error) {
@@ -880,8 +881,8 @@ func (s *GrpcServer) GetRawAddressTransactions(ctx context.Context, req *pb.GetR
 	return resp, nil
 }
 
-// GetAddressUnspentOutputs returns all the unspent transaction outpoints for the given address.
-// Offers offset, limit, and from block options.
+// GetAddressUnspentOutputs returns all the unspent transaction outputs 
+// for the given address.
 //
 // **Requires AddressIndex**
 func (s *GrpcServer) GetAddressUnspentOutputs(ctx context.Context, req *pb.GetAddressUnspentOutputsRequest) (*pb.GetAddressUnspentOutputsResponse, error) {
@@ -987,7 +988,8 @@ func (s *GrpcServer) GetAddressUnspentOutputs(ctx context.Context, req *pb.GetAd
 	return resp, nil
 }
 
-// GetUnspentOutput looks up the unspent output in the utxo set and returns the utxo metadata or not found.
+// GetUnspentOutput takes an unspent output in the utxo set and returns 
+// the utxo metadata or not found.
 func (s *GrpcServer) GetUnspentOutput(ctx context.Context, req *pb.GetUnspentOutputRequest) (*pb.GetUnspentOutputResponse, error) {
 	txnHash, err := chainhash.NewHash(req.Hash)
 	if err != nil {
@@ -1051,7 +1053,8 @@ func (s *GrpcServer) GetUnspentOutput(ctx context.Context, req *pb.GetUnspentOut
 	return ret, nil
 }
 
-// GetMerkleProof returns a merkle (SPV) proof that the given transaction is in the provided block.
+// GetMerkleProof returns a Merkle (SPV) proof for a specific transaction 
+// in the provided block.
 //
 // **Requires TxIndex***
 func (s *GrpcServer) GetMerkleProof(ctx context.Context, req *pb.GetMerkleProofRequest) (*pb.GetMerkleProofResponse, error) {
@@ -1438,8 +1441,8 @@ func (s *GrpcServer) SubscribeTransactionStream(stream pb.Bchrpc_SubscribeTransa
 	}
 }
 
-// SubscribeBlocks subscribes to notifications of new blocks being connected to the
-// blockchain or blocks being disconnected.
+// SubscribeBlocks creates a subscription for notifications of new blocks being
+// connected to the blockchain or blocks being disconnected.
 func (s *GrpcServer) SubscribeBlocks(req *pb.SubscribeBlocksRequest, stream pb.Bchrpc_SubscribeBlocksServer) error {
 	subscription := s.subscribeEvents()
 	defer subscription.Unsubscribe()

--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -881,7 +881,7 @@ func (s *GrpcServer) GetRawAddressTransactions(ctx context.Context, req *pb.GetR
 	return resp, nil
 }
 
-// GetAddressUnspentOutputs returns all the unspent transaction outputs 
+// GetAddressUnspentOutputs returns all the unspent transaction outputs
 // for the given address.
 //
 // **Requires AddressIndex**
@@ -988,7 +988,7 @@ func (s *GrpcServer) GetAddressUnspentOutputs(ctx context.Context, req *pb.GetAd
 	return resp, nil
 }
 
-// GetUnspentOutput takes an unspent output in the utxo set and returns 
+// GetUnspentOutput takes an unspent output in the utxo set and returns
 // the utxo metadata or not found.
 func (s *GrpcServer) GetUnspentOutput(ctx context.Context, req *pb.GetUnspentOutputRequest) (*pb.GetUnspentOutputResponse, error) {
 	txnHash, err := chainhash.NewHash(req.Hash)
@@ -1053,7 +1053,7 @@ func (s *GrpcServer) GetUnspentOutput(ctx context.Context, req *pb.GetUnspentOut
 	return ret, nil
 }
 
-// GetMerkleProof returns a Merkle (SPV) proof for a specific transaction 
+// GetMerkleProof returns a Merkle (SPV) proof for a specific transaction
 // in the provided block.
 //
 // **Requires TxIndex***


### PR DESCRIPTION
Add more explanatory documentation to protoc methods, types and fields.

- Makes **no change** to the protocol itself. 
- Adds specificity for terms used to refer to many things, 
- Adds synonyms for words used interchangeably 
- Aims to provides an outside audience a succinct explanation,
  or enough key terms to obtain more information elsewhere.
- Note quirks and defaults, where possible.