### PR TITLE
Default to disable relay of free (super low fee) transactions

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,7 +11,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/gcash/bchd/mining"
 	"io"
 	"net"
 	"os"
@@ -21,6 +20,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gcash/bchd/mining"
 
 	"github.com/btcsuite/go-socks/socks"
 	"github.com/gcash/bchd/chaincfg"
@@ -51,7 +52,7 @@ const (
 	defaultMaxRPCWebsockets        = 25
 	defaultMaxRPCConcurrentReqs    = 20
 	defaultDbType                  = "ffldb"
-	defaultFreeTxRelayLimit        = 15.0
+	defaultFreeTxRelayLimit        = 0
 	defaultTrickleInterval         = peer.DefaultTrickleInterval
 	defaultExcessiveBlockSize      = 32000000
 	defaultBlockMinSize            = 0


### PR DESCRIPTION
While I love the idea of relaying a percentage of transactions with a low fee, the rest of the network just doesn't accept them. Therefore, this PR updates defaultFreeTxRelayLimit to 0.

- This makes sure submitted transactions with too low a fee get an error
- This can still be activated manually if people want to attempt to relay low fee transactions.

Should help mitigate issues seen by read.cash in https://github.com/gcash/bchd/issues/382