### PR TITLE
[Feature] Return version in getnetworkinfo the way ABC/BCHN does

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -63,7 +63,11 @@ func String() string {
 
 // Numeric returns the application version as an integer.
 func Numeric() int32 {
-	return int32(2 ^ AppMajor*3 ^ AppMinor*5 ^ AppPatch)
+	major := AppMajor * 1000000
+	minor := AppMinor * 10000
+	patch := AppPatch * 100
+
+	return int32(major + minor + patch)
 }
 
 // normalizeVerString returns the passed string stripped of all characters which


### PR DESCRIPTION
Currently the version string in BCHD returns in a format different than other BCH nodes. This makes people parsing this value have a hard time, so I figured we should update it. The `version.Numeric()` function is only called in one place in any gcash code, and is exclusively used in `getnetworkinfo`.

While this is a breaking change if someone is parsing it, I think it should be fine to change without a major version bump.

Here is a sample response:

```
{
  "version": 160400,
  "subversion": "/bchd:0.16.4(EB32.0)/",
  "protocolversion": 70015,
  "localservices": "SFNodeNetwork|SFNodeBloom|SFNodeBitcoinCash|SFNodeCF",
  "localrelay": true,
  "timeoffset": 0,
  "connections": 14,
  "networkactive": true,
  "networks": [
    {
      "name": "ipv4",
      "limited": false,
      "reachable": true,
      "proxy": "",
      "proxy_randomize_credentials": false
    },
    {
      "name": "ipv6",
      "limited": false,
      "reachable": false,
      "proxy": "",
      "proxy_randomize_credentials": false
    },
    {
      "name": "onion",
      "limited": false,
      "reachable": false,
      "proxy": "",
      "proxy_randomize_credentials": false
    }
  ],
  "relayfee": 0.00001,
  "incrementalfee": 0.00001,
  "localaddresses": [
    {
      "address": "76.102.192.81",
      "port": 8333,
      "score": 4
    }
  ],
  "warnings": "Warning: Unknown block versions being mined! It's possible unknown rules are in effect."
}
```