### PR TITLE
[Feature] Update verbosity arguments to accept int or bool in getrawtransaction and searchrawtransactions

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -488,7 +488,7 @@ func NewGetRawMempoolCmd(verbose *bool) *GetRawMempoolCmd {
 // Core even though it really should be a bool.
 type GetRawTransactionCmd struct {
 	Txid    string
-	Verbose *int `jsonrpcdefault:"0"`
+	Verbose *VerbosityLevel `jsonrpcdefault:"0"`
 }
 
 // NewGetRawTransactionCmd returns a new instance which can be used to issue a
@@ -496,7 +496,7 @@ type GetRawTransactionCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewGetRawTransactionCmd(txHash string, verbose *int) *GetRawTransactionCmd {
+func NewGetRawTransactionCmd(txHash string, verbose *VerbosityLevel) *GetRawTransactionCmd {
 	return &GetRawTransactionCmd{
 		Txid:    txHash,
 		Verbose: verbose,
@@ -633,11 +633,11 @@ func NewReconsiderBlockCmd(blockHash string) *ReconsiderBlockCmd {
 // SearchRawTransactionsCmd defines the searchrawtransactions JSON-RPC command.
 type SearchRawTransactionsCmd struct {
 	Address     string
-	Verbose     *int  `jsonrpcdefault:"1"`
-	Skip        *int  `jsonrpcdefault:"0"`
-	Count       *int  `jsonrpcdefault:"100"`
-	VinExtra    *int  `jsonrpcdefault:"0"`
-	Reverse     *bool `jsonrpcdefault:"false"`
+	Verbose     *VerbosityLevel `jsonrpcdefault:"1"`
+	Skip        *int            `jsonrpcdefault:"0"`
+	Count       *int            `jsonrpcdefault:"100"`
+	VinExtra    *int            `jsonrpcdefault:"0"`
+	Reverse     *bool           `jsonrpcdefault:"false"`
 	FilterAddrs *[]string
 }
 
@@ -646,7 +646,7 @@ type SearchRawTransactionsCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewSearchRawTransactionsCmd(address string, verbose, skip, count *int, vinExtra *int, reverse *bool, filterAddrs *[]string) *SearchRawTransactionsCmd {
+func NewSearchRawTransactionsCmd(address string, verbose *VerbosityLevel, skip, count *int, vinExtra *int, reverse *bool, filterAddrs *[]string) *SearchRawTransactionsCmd {
 	return &SearchRawTransactionsCmd{
 		Address:     address,
 		Verbose:     verbose,

--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -153,6 +153,23 @@ func (v *VerbosityLevel) UnmarshalJSON(dat []byte) error {
 	return nil
 }
 
+// VerboseLevel is a type that can unmarshal a bool or an int into an int field!
+// This allows the raw API to receive either an int or a bool.
+type VerboseLevel int
+
+// UnmarshalJSON allows the VerbosityLevel to unmarshal either bool or int.
+func (v *VerboseLevel) UnmarshalJSON(dat []byte) error {
+	switch string(dat) {
+	case "0", "false":
+		*v = 0
+	case "1", "true":
+		*v = 1
+	default:
+		return errors.New("invalid VerboseLevel value")
+	}
+	return nil
+}
+
 // GetBlockCmd defines the getblock JSON-RPC command.
 type GetBlockCmd struct {
 	Hash      string
@@ -488,7 +505,7 @@ func NewGetRawMempoolCmd(verbose *bool) *GetRawMempoolCmd {
 // Core even though it really should be a bool.
 type GetRawTransactionCmd struct {
 	Txid    string
-	Verbose *VerbosityLevel `jsonrpcdefault:"0"`
+	Verbose *VerboseLevel `jsonrpcdefault:"0"`
 }
 
 // NewGetRawTransactionCmd returns a new instance which can be used to issue a
@@ -496,7 +513,7 @@ type GetRawTransactionCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewGetRawTransactionCmd(txHash string, verbose *VerbosityLevel) *GetRawTransactionCmd {
+func NewGetRawTransactionCmd(txHash string, verbose *VerboseLevel) *GetRawTransactionCmd {
 	return &GetRawTransactionCmd{
 		Txid:    txHash,
 		Verbose: verbose,
@@ -633,11 +650,11 @@ func NewReconsiderBlockCmd(blockHash string) *ReconsiderBlockCmd {
 // SearchRawTransactionsCmd defines the searchrawtransactions JSON-RPC command.
 type SearchRawTransactionsCmd struct {
 	Address     string
-	Verbose     *VerbosityLevel `jsonrpcdefault:"1"`
-	Skip        *int            `jsonrpcdefault:"0"`
-	Count       *int            `jsonrpcdefault:"100"`
-	VinExtra    *int            `jsonrpcdefault:"0"`
-	Reverse     *bool           `jsonrpcdefault:"false"`
+	Verbose     *VerboseLevel `jsonrpcdefault:"1"`
+	Skip        *int          `jsonrpcdefault:"0"`
+	Count       *int          `jsonrpcdefault:"100"`
+	VinExtra    *int          `jsonrpcdefault:"0"`
+	Reverse     *bool         `jsonrpcdefault:"false"`
 	FilterAddrs *[]string
 }
 
@@ -646,7 +663,7 @@ type SearchRawTransactionsCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewSearchRawTransactionsCmd(address string, verbose *VerbosityLevel, skip, count *int, vinExtra *int, reverse *bool, filterAddrs *[]string) *SearchRawTransactionsCmd {
+func NewSearchRawTransactionsCmd(address string, verbose *VerboseLevel, skip, count *int, vinExtra *int, reverse *bool, filterAddrs *[]string) *SearchRawTransactionsCmd {
 	return &SearchRawTransactionsCmd{
 		Address:     address,
 		Verbose:     verbose,

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -641,7 +641,7 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"getrawtransaction","params":["123"],"id":1}`,
 			unmarshalled: &btcjson.GetRawTransactionCmd{
 				Txid:    "123",
-				Verbose: btcjson.Int(0),
+				Verbose: btcjson.Vlevel(0),
 			},
 		},
 		{
@@ -650,12 +650,26 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getrawtransaction", "123", 1)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetRawTransactionCmd("123", btcjson.Int(1))
+				return btcjson.NewGetRawTransactionCmd("123", btcjson.Vlevel(1))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawtransaction","params":["123",1],"id":1}`,
 			unmarshalled: &btcjson.GetRawTransactionCmd{
 				Txid:    "123",
-				Verbose: btcjson.Int(1),
+				Verbose: btcjson.Vlevel(1),
+			},
+		},
+		{
+			name: "getrawtransaction optional bool",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getrawtransaction", "123", true)
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetRawTransactionCmd("123", btcjson.Vlevel(1))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getrawtransaction","params":["123",1],"id":1}`,
+			unmarshalled: &btcjson.GetRawTransactionCmd{
+				Txid:    "123",
+				Verbose: btcjson.Vlevel(1),
 			},
 		},
 		{
@@ -842,7 +856,26 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address"],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Int(1),
+				Verbose:     btcjson.Vlevel(1),
+				Skip:        btcjson.Int(0),
+				Count:       btcjson.Int(100),
+				VinExtra:    btcjson.Int(0),
+				Reverse:     btcjson.Bool(false),
+				FilterAddrs: nil,
+			},
+		},
+		{
+			name: "searchrawtransactions",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("searchrawtransactions", "1Address", true)
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewSearchRawTransactionsCmd("1Address", btcjson.Vlevel(1), nil, nil, nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",1],"id":1}`,
+			unmarshalled: &btcjson.SearchRawTransactionsCmd{
+				Address:     "1Address",
+				Verbose:     btcjson.Vlevel(1),
 				Skip:        btcjson.Int(0),
 				Count:       btcjson.Int(100),
 				VinExtra:    btcjson.Int(0),
@@ -857,12 +890,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), nil, nil, nil, nil, nil)
+					btcjson.Vlevel(0), nil, nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Int(0),
+				Verbose:     btcjson.Vlevel(0),
 				Skip:        btcjson.Int(0),
 				Count:       btcjson.Int(100),
 				VinExtra:    btcjson.Int(0),
@@ -877,12 +910,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), btcjson.Int(5), nil, nil, nil, nil)
+					btcjson.Vlevel(0), btcjson.Int(5), nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Int(0),
+				Verbose:     btcjson.Vlevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(100),
 				VinExtra:    btcjson.Int(0),
@@ -897,12 +930,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), nil, nil, nil)
+					btcjson.Vlevel(0), btcjson.Int(5), btcjson.Int(10), nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Int(0),
+				Verbose:     btcjson.Vlevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(10),
 				VinExtra:    btcjson.Int(0),
@@ -917,12 +950,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), nil, nil)
+					btcjson.Vlevel(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Int(0),
+				Verbose:     btcjson.Vlevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(10),
 				VinExtra:    btcjson.Int(1),
@@ -937,12 +970,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), nil)
+					btcjson.Vlevel(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Int(0),
+				Verbose:     btcjson.Vlevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(10),
 				VinExtra:    btcjson.Int(1),
@@ -957,12 +990,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), &[]string{"1Address"})
+					btcjson.Vlevel(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), &[]string{"1Address"})
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true,["1Address"]],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Int(0),
+				Verbose:     btcjson.Vlevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(10),
 				VinExtra:    btcjson.Int(1),

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -160,12 +160,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getblock", "123", btcjson.Int(0))
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetBlockCmd("123", btcjson.Vlevel(0))
+				return btcjson.NewGetBlockCmd("123", btcjson.Verbositylevel(0))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123",0],"id":1}`,
 			unmarshalled: &btcjson.GetBlockCmd{
 				Hash:      "123",
-				Verbosity: btcjson.Vlevel(0),
+				Verbosity: btcjson.Verbositylevel(0),
 			},
 		},
 		{
@@ -179,7 +179,7 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123"],"id":1}`,
 			unmarshalled: &btcjson.GetBlockCmd{
 				Hash:      "123",
-				Verbosity: btcjson.Vlevel(1),
+				Verbosity: btcjson.Verbositylevel(1),
 			},
 		},
 		{
@@ -188,12 +188,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getblock", "123", btcjson.Int(1))
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetBlockCmd("123", btcjson.Vlevel(1))
+				return btcjson.NewGetBlockCmd("123", btcjson.Verbositylevel(1))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123",1],"id":1}`,
 			unmarshalled: &btcjson.GetBlockCmd{
 				Hash:      "123",
-				Verbosity: btcjson.Vlevel(1),
+				Verbosity: btcjson.Verbositylevel(1),
 			},
 		},
 		{
@@ -202,12 +202,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getblock", "123", btcjson.Int(2))
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetBlockCmd("123", btcjson.Vlevel(2))
+				return btcjson.NewGetBlockCmd("123", btcjson.Verbositylevel(2))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123",2],"id":1}`,
 			unmarshalled: &btcjson.GetBlockCmd{
 				Hash:      "123",
-				Verbosity: btcjson.Vlevel(2),
+				Verbosity: btcjson.Verbositylevel(2),
 			},
 		},
 		{
@@ -216,12 +216,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getblock", "123", btcjson.String("true"))
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetBlockCmd("123", btcjson.Vlevel(1))
+				return btcjson.NewGetBlockCmd("123", btcjson.Verbositylevel(1))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123",1],"id":1}`,
 			unmarshalled: &btcjson.GetBlockCmd{
 				Hash:      "123",
-				Verbosity: btcjson.Vlevel(1),
+				Verbosity: btcjson.Verbositylevel(1),
 			},
 		},
 		{
@@ -230,12 +230,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getblock", "123", btcjson.String("false"))
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetBlockCmd("123", btcjson.Vlevel(0))
+				return btcjson.NewGetBlockCmd("123", btcjson.Verbositylevel(0))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123",0],"id":1}`,
 			unmarshalled: &btcjson.GetBlockCmd{
 				Hash:      "123",
-				Verbosity: btcjson.Vlevel(0),
+				Verbosity: btcjson.Verbositylevel(0),
 			},
 		},
 		{
@@ -244,12 +244,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getblock", "123", btcjson.Bool(true))
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetBlockCmd("123", btcjson.Vlevel(1))
+				return btcjson.NewGetBlockCmd("123", btcjson.Verbositylevel(1))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123",1],"id":1}`,
 			unmarshalled: &btcjson.GetBlockCmd{
 				Hash:      "123",
-				Verbosity: btcjson.Vlevel(1),
+				Verbosity: btcjson.Verbositylevel(1),
 			},
 		},
 		{
@@ -258,12 +258,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getblock", "123", btcjson.Bool(false))
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetBlockCmd("123", btcjson.Vlevel(0))
+				return btcjson.NewGetBlockCmd("123", btcjson.Verbositylevel(0))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123",0],"id":1}`,
 			unmarshalled: &btcjson.GetBlockCmd{
 				Hash:      "123",
-				Verbosity: btcjson.Vlevel(0),
+				Verbosity: btcjson.Verbositylevel(0),
 			},
 		},
 		{
@@ -641,7 +641,7 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"getrawtransaction","params":["123"],"id":1}`,
 			unmarshalled: &btcjson.GetRawTransactionCmd{
 				Txid:    "123",
-				Verbose: btcjson.Vlevel(0),
+				Verbose: btcjson.Verboselevel(0),
 			},
 		},
 		{
@@ -650,12 +650,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getrawtransaction", "123", 1)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetRawTransactionCmd("123", btcjson.Vlevel(1))
+				return btcjson.NewGetRawTransactionCmd("123", btcjson.Verboselevel(1))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawtransaction","params":["123",1],"id":1}`,
 			unmarshalled: &btcjson.GetRawTransactionCmd{
 				Txid:    "123",
-				Verbose: btcjson.Vlevel(1),
+				Verbose: btcjson.Verboselevel(1),
 			},
 		},
 		{
@@ -664,12 +664,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getrawtransaction", "123", true)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetRawTransactionCmd("123", btcjson.Vlevel(1))
+				return btcjson.NewGetRawTransactionCmd("123", btcjson.Verboselevel(1))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawtransaction","params":["123",1],"id":1}`,
 			unmarshalled: &btcjson.GetRawTransactionCmd{
 				Txid:    "123",
-				Verbose: btcjson.Vlevel(1),
+				Verbose: btcjson.Verboselevel(1),
 			},
 		},
 		{
@@ -856,7 +856,7 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address"],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Vlevel(1),
+				Verbose:     btcjson.Verboselevel(1),
 				Skip:        btcjson.Int(0),
 				Count:       btcjson.Int(100),
 				VinExtra:    btcjson.Int(0),
@@ -870,12 +870,12 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("searchrawtransactions", "1Address", true)
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewSearchRawTransactionsCmd("1Address", btcjson.Vlevel(1), nil, nil, nil, nil, nil)
+				return btcjson.NewSearchRawTransactionsCmd("1Address", btcjson.Verboselevel(1), nil, nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",1],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Vlevel(1),
+				Verbose:     btcjson.Verboselevel(1),
 				Skip:        btcjson.Int(0),
 				Count:       btcjson.Int(100),
 				VinExtra:    btcjson.Int(0),
@@ -890,12 +890,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Vlevel(0), nil, nil, nil, nil, nil)
+					btcjson.Verboselevel(0), nil, nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Vlevel(0),
+				Verbose:     btcjson.Verboselevel(0),
 				Skip:        btcjson.Int(0),
 				Count:       btcjson.Int(100),
 				VinExtra:    btcjson.Int(0),
@@ -910,12 +910,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Vlevel(0), btcjson.Int(5), nil, nil, nil, nil)
+					btcjson.Verboselevel(0), btcjson.Int(5), nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Vlevel(0),
+				Verbose:     btcjson.Verboselevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(100),
 				VinExtra:    btcjson.Int(0),
@@ -930,12 +930,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Vlevel(0), btcjson.Int(5), btcjson.Int(10), nil, nil, nil)
+					btcjson.Verboselevel(0), btcjson.Int(5), btcjson.Int(10), nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Vlevel(0),
+				Verbose:     btcjson.Verboselevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(10),
 				VinExtra:    btcjson.Int(0),
@@ -950,12 +950,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Vlevel(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), nil, nil)
+					btcjson.Verboselevel(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Vlevel(0),
+				Verbose:     btcjson.Verboselevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(10),
 				VinExtra:    btcjson.Int(1),
@@ -970,12 +970,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Vlevel(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), nil)
+					btcjson.Verboselevel(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Vlevel(0),
+				Verbose:     btcjson.Verboselevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(10),
 				VinExtra:    btcjson.Int(1),
@@ -990,12 +990,12 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Vlevel(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), &[]string{"1Address"})
+					btcjson.Verboselevel(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), &[]string{"1Address"})
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true,["1Address"]],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     btcjson.Vlevel(0),
+				Verbose:     btcjson.Verboselevel(0),
 				Skip:        btcjson.Int(5),
 				Count:       btcjson.Int(10),
 				VinExtra:    btcjson.Int(1),

--- a/btcjson/example_test.go
+++ b/btcjson/example_test.go
@@ -21,7 +21,7 @@ func ExampleMarshalCmd() {
 	// convenience function for creating a pointer out of a primitive for
 	// optional parameters.
 	blockHash := "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
-	gbCmd := btcjson.NewGetBlockCmd(blockHash, btcjson.Vlevel(0))
+	gbCmd := btcjson.NewGetBlockCmd(blockHash, btcjson.Verbositylevel(0))
 
 	// Marshal the command to the format suitable for sending to the RPC
 	// server.  Typically the client would increment the id here which is

--- a/btcjson/helpers.go
+++ b/btcjson/helpers.go
@@ -76,10 +76,18 @@ func String(v string) *string {
 	return p
 }
 
-// Vlevel is a helper routine that allocates a new VerbosityLevel value to
+// Verbositylevel is a helper routine that allocates a new VerbosityLevel value to
 // store v and returns a pointer to it. This is useful when assigning optional parameters.
-func Vlevel(v VerbosityLevel) *VerbosityLevel {
+func Verbositylevel(v VerbosityLevel) *VerbosityLevel {
 	p := new(VerbosityLevel)
+	*p = v
+	return p
+}
+
+// Verboselevel is a helper routine that allocates a new VerbosityLevel value to
+// store v and returns a pointer to it. This is useful when assigning optional parameters.
+func Verboselevel(v VerboseLevel) *VerboseLevel {
+	p := new(VerboseLevel)
 	*p = v
 	return p
 }

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -143,7 +143,7 @@ func (c *Client) GetBlockAsync(blockHash *chainhash.Hash) FutureGetBlockResult {
 		hash = blockHash.String()
 	}
 
-	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Vlevel(0))
+	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Verbositylevel(0))
 	return FutureGetBlockResult{
 		client:   c,
 		hash:     hash,
@@ -196,7 +196,7 @@ func (c *Client) GetBlockVerboseAsync(blockHash *chainhash.Hash, verboseTx bool)
 	}
 	// From the bitcoin-cli getblock documentation:
 	// "If verbosity is 1, returns an Object with information about block ."
-	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Vlevel(1))
+	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Verbositylevel(1))
 	return FutureGetBlockVerboseResult{
 		client:   c,
 		hash:     hash,
@@ -251,7 +251,7 @@ func (c *Client) GetBlockVerboseTxAsync(blockHash *chainhash.Hash) FutureGetBloc
 	// From the bitcoin-cli getblock documentation:
 	// If verbosity is 2, returns an Object with information about block
 	// and information about each transaction
-	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Vlevel(2))
+	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Verbositylevel(2))
 	return FutureGetBlockVerboseTxResult{
 		client:   c,
 		hash:     hash,

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -103,7 +103,7 @@ func (c *Client) GetRawTransactionAsync(txHash *chainhash.Hash) FutureGetRawTran
 		hash = txHash.String()
 	}
 
-	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Int(0))
+	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Vlevel(0))
 	return c.sendCmd(cmd)
 }
 
@@ -149,7 +149,7 @@ func (c *Client) GetRawTransactionVerboseAsync(txHash *chainhash.Hash) FutureGet
 		hash = txHash.String()
 	}
 
-	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Int(1))
+	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Vlevel(1))
 	return c.sendCmd(cmd)
 }
 
@@ -561,7 +561,7 @@ func (r FutureSearchRawTransactionsResult) Receive() ([]*wire.MsgTx, error) {
 // See SearchRawTransactions for the blocking version and more details.
 func (c *Client) SearchRawTransactionsAsync(address bchutil.Address, skip, count int, reverse bool, filterAddrs []string) FutureSearchRawTransactionsResult {
 	addr := address.EncodeAddress()
-	verbose := btcjson.Int(0)
+	verbose := btcjson.Vlevel(0)
 	cmd := btcjson.NewSearchRawTransactionsCmd(addr, verbose, &skip, &count,
 		nil, &reverse, &filterAddrs)
 	return c.sendCmd(cmd)
@@ -610,7 +610,7 @@ func (c *Client) SearchRawTransactionsVerboseAsync(address bchutil.Address, skip
 	count int, includePrevOut, reverse bool, filterAddrs *[]string) FutureSearchRawTransactionsVerboseResult {
 
 	addr := address.EncodeAddress()
-	verbose := btcjson.Int(1)
+	verbose := btcjson.Vlevel(1)
 	var prevOut *int
 	if includePrevOut {
 		prevOut = btcjson.Int(1)

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -103,7 +103,7 @@ func (c *Client) GetRawTransactionAsync(txHash *chainhash.Hash) FutureGetRawTran
 		hash = txHash.String()
 	}
 
-	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Vlevel(0))
+	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Verboselevel(0))
 	return c.sendCmd(cmd)
 }
 
@@ -149,7 +149,7 @@ func (c *Client) GetRawTransactionVerboseAsync(txHash *chainhash.Hash) FutureGet
 		hash = txHash.String()
 	}
 
-	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Vlevel(1))
+	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Verboselevel(1))
 	return c.sendCmd(cmd)
 }
 
@@ -561,7 +561,7 @@ func (r FutureSearchRawTransactionsResult) Receive() ([]*wire.MsgTx, error) {
 // See SearchRawTransactions for the blocking version and more details.
 func (c *Client) SearchRawTransactionsAsync(address bchutil.Address, skip, count int, reverse bool, filterAddrs []string) FutureSearchRawTransactionsResult {
 	addr := address.EncodeAddress()
-	verbose := btcjson.Vlevel(0)
+	verbose := btcjson.Verboselevel(0)
 	cmd := btcjson.NewSearchRawTransactionsCmd(addr, verbose, &skip, &count,
 		nil, &reverse, &filterAddrs)
 	return c.sendCmd(cmd)
@@ -610,7 +610,7 @@ func (c *Client) SearchRawTransactionsVerboseAsync(address bchutil.Address, skip
 	count int, includePrevOut, reverse bool, filterAddrs *[]string) FutureSearchRawTransactionsVerboseResult {
 
 	addr := address.EncodeAddress()
-	verbose := btcjson.Vlevel(1)
+	verbose := btcjson.Verboselevel(1)
 	var prevOut *int
 	if includePrevOut {
 		prevOut = btcjson.Int(1)


### PR DESCRIPTION
Updated the remaining Verbose/Verbosity arguments found in the RPC to handle either int or bool values. This fixes the last quirk mentioned in https://github.com/gcash/bchd/issues/385.

The updated methods were:

- getrawtransaction
- searchrawtransactions

Note: there is some important naming.

`VerbosityLevel` allows [0,1,2,true,false] to support `getblock`
`VerboseLevel` allows [0,1,true,false] to support `getrawtransaction` and `searchrawtransactions`.

Here is some sample working curl calls.

```
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "getrawtransaction", "params": ["9d7cb019c6cdba505193a70e60d59b8f2145afa79065c957e05c6389630249b0"] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "getrawtransaction", "params": ["9d7cb019c6cdba505193a70e60d59b8f2145afa79065c957e05c6389630249b0",0] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "getrawtransaction", "params": ["9d7cb019c6cdba505193a70e60d59b8f2145afa79065c957e05c6389630249b0",1] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "getrawtransaction", "params": ["9d7cb019c6cdba505193a70e60d59b8f2145afa79065c957e05c6389630249b0",true] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "getrawtransaction", "params": ["9d7cb019c6cdba505193a70e60d59b8f2145afa79065c957e05c6389630249b0",false] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "searchrawtransactions", "params": ["bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx"] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "searchrawtransactions", "params": ["bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx",0] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "searchrawtransactions", "params": ["bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx",1] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "searchrawtransactions", "params": ["bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx",false] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "searchrawtransactions", "params": ["bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx",true] }' -k
```

Invalid calls.

```
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "getrawtransaction", "params": ["9d7cb019c6cdba505193a70e60d59b8f2145afa79065c957e05c6389630249b0",2] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "getrawtransaction", "params": ["9d7cb019c6cdba505193a70e60d59b8f2145afa79065c957e05c6389630249b0","bad"] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "searchrawtransactions", "params": ["bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx",2] }' -k
curl --header "Content-Type: application/json" https://127.0.0.1:8334/ -d '{ "jsonrpc": "2.0", "id":   1, "method": "searchrawtransactions", "params": ["bitcoincash:qrhea03074073ff3zv9whh0nggxc7k03ssh8jv9mkx","bad"] }' -k
```

@cculianu you can test and make sure it fixes the issue you brought up. =)