### PR TITLE
Added protobuffer package for Java.

### DIFF
--- a/bchrpc/bchrpc.proto
+++ b/bchrpc/bchrpc.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package pb;
-option java_package = "com.bchd.rpc";
+option java_package = "cash.bchd.rpc";
 
 // bchrpc contains a set of RPCs that can be exposed publicly via
 // the command line options. This service could be authenticated or

--- a/bchrpc/bchrpc.proto
+++ b/bchrpc/bchrpc.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package pb;
+option java_package = "com.bchd.rpc";
 
 // bchrpc contains a set of RPCs that can be exposed publicly via
 // the command line options. This service could be authenticated or


### PR DESCRIPTION
The previous protobuffer package generated for java is set to "pb", which
created a strange structuring when imported into Java.  This change moves
the generated code to com.bchd.rpc.Bchrpc.