### PR TITLE
[Bug] Update max standard tx size to 100k

### DIFF
--- a/btcjson/cmdparse_test.go
+++ b/btcjson/cmdparse_test.go
@@ -201,7 +201,7 @@ func TestAssignFieldErrors(t *testing.T) {
 	}{
 		{
 			name: "general incompatible int -> string",
-			dest: string(0),
+			dest: string(rune(0)),
 			src:  int(0),
 			err:  btcjson.Error{ErrorCode: btcjson.ErrInvalidType},
 		},

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -47,7 +47,7 @@ const (
 	maxStandardMultiSigKeys = 3
 
 	// maxStandardTxSize is the maximum size of a transaction
-	maxStandardTxSize = 1000000
+	maxStandardTxSize = 100000
 )
 
 // calcMinRequiredTxRelayFee returns the minimum transaction fee required for a
@@ -261,9 +261,9 @@ func checkTransactionStandard(tx *bchutil.Tx, height int32,
 	// size of a transaction.  This also helps mitigate CPU exhaustion
 	// attacks.
 	txSize := tx.MsgTx().SerializeSize()
-	if txSize > blockchain.MaxTransactionSize {
+	if txSize > maxStandardTxSize {
 		str := fmt.Sprintf("size of transaction %v is larger than max "+
-			"allowed size of %v", txSize, blockchain.MaxTransactionSize)
+			"allowed size of %v", txSize, maxStandardTxSize)
 		return txRuleError(wire.RejectNonstandard, str)
 	}
 

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -43,7 +43,7 @@ func TestCalcMinRequiredTxRelayFee(t *testing.T) {
 			"max standard tx size with default minimum relay fee",
 			maxStandardTxSize,
 			DefaultMinRelayTxFee,
-			1000000,
+			100000,
 		},
 		{
 			"max standard tx size with max satoshi relay fee",

--- a/upnp.go
+++ b/upnp.go
@@ -36,6 +36,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -229,7 +230,7 @@ func getServiceURL(rootURL string) (url string, err error) {
 	}
 	defer r.Body.Close()
 	if r.StatusCode >= 400 {
-		err = errors.New(string(r.StatusCode))
+		err = errors.New(fmt.Sprint(r.StatusCode))
 		return
 	}
 	var root root

--- a/wire/message.go
+++ b/wire/message.go
@@ -243,7 +243,7 @@ func readMessageHeader(r io.Reader) (int, *messageHeader, error) {
 	readElements(hr, &hdr.magic, &command, &hdr.length, &hdr.checksum)
 
 	// Strip trailing zeros from command string.
-	hdr.command = string(bytes.TrimRight(command[:], string(0)))
+	hdr.command = string(bytes.TrimRight(command[:], string(rune(0))))
 
 	return n, &hdr, nil
 }


### PR DESCRIPTION
This was checking for 1MB which is the consensus rule. It should be checking the standardness rule in this function!