### PR TITLE
Double Spend Proofs

### DIFF
--- a/netsync/common_test.go
+++ b/netsync/common_test.go
@@ -160,6 +160,7 @@ func WaitUntil(fn func() bool, timeout time.Duration) bool {
 // the call arguments in a channel for a receiver to make assertions about.
 type MockPeerNotifier struct {
 	announceNewTransactionsChan chan *announceNewTransactionsCall
+	announceNewDSProofChan      chan *announceNewDSProofCall
 	updatePeerHeightsChan       chan *updatePeerHeightsCall
 	relayInventoryChan          chan *relayInventoryCall
 	transactionConfirmedChan    chan *transactionConfirmedCall
@@ -167,6 +168,10 @@ type MockPeerNotifier struct {
 
 type announceNewTransactionsCall struct {
 	newTxs []*mempool.TxDesc
+}
+
+type announceNewDSProofCall struct {
+	newDSProof *wire.MsgDSProof
 }
 
 type updatePeerHeightsCall struct {
@@ -187,6 +192,12 @@ type transactionConfirmedCall struct {
 func (mock *MockPeerNotifier) AnnounceNewTransactions(newTxs []*mempool.TxDesc) {
 	mock.announceNewTransactionsChan <- &announceNewTransactionsCall{
 		newTxs: newTxs,
+	}
+}
+
+func (mock *MockPeerNotifier) AnnounceNewDSProof(newDSProof *wire.MsgDSProof) {
+	mock.announceNewDSProofChan <- &announceNewDSProofCall{
+		newDSProof: newDSProof,
 	}
 }
 
@@ -214,6 +225,7 @@ func (mock *MockPeerNotifier) TransactionConfirmed(tx *bchutil.Tx) {
 func NewMockPeerNotifier() *MockPeerNotifier {
 	return &MockPeerNotifier{
 		announceNewTransactionsChan: make(chan *announceNewTransactionsCall, 10),
+		announceNewDSProofChan:      make(chan *announceNewDSProofCall, 10),
 		updatePeerHeightsChan:       make(chan *updatePeerHeightsCall, 10),
 		relayInventoryChan:          make(chan *relayInventoryCall, 10),
 		transactionConfirmedChan:    make(chan *transactionConfirmedCall, 10),

--- a/netsync/interface.go
+++ b/netsync/interface.go
@@ -20,6 +20,8 @@ import (
 type PeerNotifier interface {
 	AnnounceNewTransactions(newTxs []*mempool.TxDesc)
 
+	AnnounceNewDSProof(newDSProof *wire.MsgDSProof)
+
 	UpdatePeerHeights(latestBlkHash *chainhash.Hash, latestHeight int32, updateSource *peer.Peer)
 
 	RelayInventory(invVect *wire.InvVect, data interface{})

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -745,7 +745,7 @@ func (sm *SyncManager) handleDSProofMsg(dsmsg *dsProofMsg) {
 	}
 
 	// Process the proof to include validation, insertion in the memory pool.
-	err := sm.txMemPool.ProcessDSProof(dsmsg.msg)
+	isOrphan, err := sm.txMemPool.ProcessDSProof(dsmsg.msg)
 
 	// Remove proof from request maps. Either the mempool/chain
 	// already knows about it and as such we shouldn't have any more
@@ -779,7 +779,9 @@ func (sm *SyncManager) handleDSProofMsg(dsmsg *dsProofMsg) {
 		return
 	}
 
-	sm.peerNotifier.AnnounceNewDSProof(dsmsg.msg)
+	if !isOrphan {
+		sm.peerNotifier.AnnounceNewDSProof(dsmsg.msg)
+	}
 }
 
 // current returns true if we believe we are synced with our peers, false if we

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// MaxProtocolVersion is the max protocol version the peer supports.
-	MaxProtocolVersion = wire.NoValidationRelayVersion
+	MaxProtocolVersion = wire.DoubleSpendProofVersion
 
 	// DefaultTrickleInterval is the min time between attempts to send an
 	// inv message to a peer.
@@ -216,6 +216,10 @@ type MessageListeners struct {
 	// OnBlockTxns is invoked when a peer receives a blocktxns bitcoin
 	// message.
 	OnBlockTxns func(p *Peer, msg *wire.MsgBlockTxns)
+
+	// OnDSProof is invoked when a peer receives a dsproof bitcoin
+	// message.
+	OnDSProof func(p *Peer, msg *wire.MsgDSProof)
 
 	// OnRead is invoked when a peer receives a bitcoin message.  It
 	// consists of the number of bytes read, the message, and whether or not
@@ -1712,6 +1716,11 @@ out:
 		case *wire.MsgBlockTxns:
 			if p.cfg.Listeners.OnBlockTxns != nil {
 				p.cfg.Listeners.OnBlockTxns(p, msg)
+			}
+
+		case *wire.MsgDSProof:
+			if p.cfg.Listeners.OnDSProof != nil {
+				p.cfg.Listeners.OnDSProof(p, msg)
 			}
 
 		default:

--- a/wire/invvect.go
+++ b/wire/invvect.go
@@ -30,6 +30,7 @@ const (
 	InvTypeBlock         InvType = 2
 	InvTypeFilteredBlock InvType = 3
 	InvTypeCmpctBlock    InvType = 4
+	InvTypeDSProof       InvType = 0x94a0
 )
 
 // Map of service flags back to their constant names for pretty printing.
@@ -39,6 +40,7 @@ var ivStrings = map[InvType]string{
 	InvTypeBlock:         "MSG_BLOCK",
 	InvTypeFilteredBlock: "MSG_FILTERED_BLOCK",
 	InvTypeCmpctBlock:    "MSG_CMPCT_BLOCK",
+	InvTypeDSProof:       "MSG_DOUBLE_SPEND_PROOF",
 }
 
 // String returns the InvType in human-readable form.

--- a/wire/invvect_test.go
+++ b/wire/invvect_test.go
@@ -125,6 +125,21 @@ func TestInvVectWire(t *testing.T) {
 		0x26, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Block 203707 hash
 	}
 
+	// dsProofInvVect is an inventory vector representing a compact block.
+	dsProofInvVect := InvVect{
+		Type: InvTypeDSProof,
+		Hash: *baseHash,
+	}
+
+	// dsProofInvVectEncoded is the wire encoded bytes of dsProofInvVect.
+	dsProofInvVectEncoded := []byte{
+		0xa0, 0x94, 0x00, 0x00, // InvTypeDSProof
+		0xdc, 0xe9, 0x69, 0x10, 0x94, 0xda, 0x23, 0xc7,
+		0xe7, 0x67, 0x13, 0xd0, 0x75, 0xd4, 0xa1, 0x0b,
+		0x79, 0x40, 0x08, 0xa6, 0x36, 0xac, 0xc2, 0x4b,
+		0x26, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Block 203707 hash
+	}
+
 	tests := []struct {
 		in   InvVect // NetAddress to encode
 		out  InvVect // Expected decoded NetAddress
@@ -288,6 +303,14 @@ func TestInvVectWire(t *testing.T) {
 			cmpctBlockInvVect,
 			cmpctBlockInvVect,
 			cmpctBlockInvVectEncoded,
+			MultipleAddressVersion,
+		},
+
+		// Protocol version MultipleAddressVersion dsproof inventory vector.
+		{
+			dsProofInvVect,
+			dsProofInvVect,
+			dsProofInvVectEncoded,
 			MultipleAddressVersion,
 		},
 	}

--- a/wire/invvect_test.go
+++ b/wire/invvect_test.go
@@ -125,7 +125,7 @@ func TestInvVectWire(t *testing.T) {
 		0x26, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Block 203707 hash
 	}
 
-	// dsProofInvVect is an inventory vector representing a compact block.
+	// dsProofInvVect is an inventory vector representing a dsproof.
 	dsProofInvVect := InvVect{
 		Type: InvTypeDSProof,
 		Hash: *baseHash,

--- a/wire/message.go
+++ b/wire/message.go
@@ -74,6 +74,7 @@ const (
 	CmdCmpctBlock   = "cmpctblock"
 	CmdGetBlockTxns = "getblocktxn"
 	CmdBlockTxns    = "blocktxn"
+	CmdDSProof      = "dsproof-beta"
 )
 
 // MessageEncoding represents the wire message encoding format to be used.
@@ -209,6 +210,9 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdBlockTxns:
 		msg = &MsgBlockTxns{}
+
+	case CmdDSProof:
+		msg = &MsgDSProof{}
 
 	default:
 		return nil, fmt.Errorf("unhandled command [%s]", command)

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -75,6 +75,7 @@ func TestMessage(t *testing.T) {
 		[]byte("payload"))
 	msgCFHeaders := NewMsgCFHeaders()
 	msgCFCheckpt := NewMsgCFCheckpt(GCSFilterRegular, &chainhash.Hash{}, 0)
+	msgDSProof := NewMsgDSProof(OutPoint{}, Spender{PushData: make([][]byte, 0)}, Spender{PushData: make([][]byte, 0)})
 
 	tests := []struct {
 		in     Message    // Value to encode
@@ -109,6 +110,7 @@ func TestMessage(t *testing.T) {
 		{msgCFilter, msgCFilter, pver, MainNet, 65},
 		{msgCFHeaders, msgCFHeaders, pver, MainNet, 90},
 		{msgCFCheckpt, msgCFCheckpt, pver, MainNet, 58},
+		{msgDSProof, msgDSProof, pver, MainNet, 278},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/wire/msgdsproof.go
+++ b/wire/msgdsproof.go
@@ -1,0 +1,240 @@
+package wire
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/gcash/bchd/chaincfg/chainhash"
+	"io"
+)
+
+// MsgDSProof implements the Message interface and represents a Bitcoin dsproof
+// message.  It is relayed to all peers upon detecting a double spend.
+type MsgDSProof struct {
+	TxInPrevHash  chainhash.Hash
+	TxInPrevIndex uint32
+	FirstSpender  Spender
+	DoubleSpender Spender
+}
+
+// Spender contains a proof that a given input was was signed, but it intentionally
+// does not provide enough data to reconstruct the full transaction. Only enough
+// to validate the signature.
+type Spender struct {
+	Version         int32
+	Sequence        uint32
+	LockTime        uint32
+	HashPrevOutputs chainhash.Hash
+	HashSequence    chainhash.Hash
+	HashOutputs     chainhash.Hash
+	PushData        [][]byte
+}
+
+// BchDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgDSProof) BchDecode(r io.Reader, pver uint32, enc MessageEncoding) error {
+	if pver < DoubleSpendProofVersion {
+		str := fmt.Sprintf("dsproof message invalid for protocol "+
+			"version %d", pver)
+		return messageError("MsgDSProof.BchDecode", str)
+	}
+
+	_, err := io.ReadFull(r, msg.TxInPrevHash[:])
+	if err != nil {
+		return err
+	}
+
+	msg.TxInPrevIndex, err = binarySerializer.Uint32(r, littleEndian)
+	if err != nil {
+		return err
+	}
+
+	firstSpenderVersion, err := binarySerializer.Uint32(r, littleEndian)
+	if err != nil {
+		return err
+	}
+	msg.FirstSpender.Version = int32(firstSpenderVersion)
+
+	firstSpenderSequence, err := binarySerializer.Uint32(r, littleEndian)
+	if err != nil {
+		return err
+	}
+	msg.FirstSpender.Sequence = firstSpenderSequence
+
+	firstSpenderLocktime, err := binarySerializer.Uint32(r, littleEndian)
+	if err != nil {
+		return err
+	}
+	msg.FirstSpender.LockTime = firstSpenderLocktime
+
+	_, err = io.ReadFull(r, msg.FirstSpender.HashPrevOutputs[:])
+	if err != nil {
+		return err
+	}
+
+	_, err = io.ReadFull(r, msg.FirstSpender.HashSequence[:])
+	if err != nil {
+		return err
+	}
+
+	_, err = io.ReadFull(r, msg.FirstSpender.HashOutputs[:])
+	if err != nil {
+		return err
+	}
+
+	numFirstSpenderPushDatas, err := ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+
+	msg.FirstSpender.PushData = make([][]byte, numFirstSpenderPushDatas)
+
+	for i := 0; i < int(numFirstSpenderPushDatas); i++ {
+		msg.FirstSpender.PushData[i], err = ReadVarBytes(r, pver, 512,
+			"First spender push data")
+		if err != nil {
+			return err
+		}
+	}
+
+	doubleSpenderVersion, err := binarySerializer.Uint32(r, littleEndian)
+	if err != nil {
+		return err
+	}
+	msg.FirstSpender.Version = int32(doubleSpenderVersion)
+
+	doubleSpenderSequence, err := binarySerializer.Uint32(r, littleEndian)
+	if err != nil {
+		return err
+	}
+	msg.FirstSpender.Sequence = doubleSpenderSequence
+
+	doubleSpenderLocktime, err := binarySerializer.Uint32(r, littleEndian)
+	if err != nil {
+		return err
+	}
+	msg.DoubleSpender.LockTime = doubleSpenderLocktime
+
+	_, err = io.ReadFull(r, msg.DoubleSpender.HashPrevOutputs[:])
+	if err != nil {
+		return err
+	}
+
+	_, err = io.ReadFull(r, msg.DoubleSpender.HashSequence[:])
+	if err != nil {
+		return err
+	}
+
+	_, err = io.ReadFull(r, msg.DoubleSpender.HashOutputs[:])
+	if err != nil {
+		return err
+	}
+
+	numDoubleSpenderPushDatas, err := ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+
+	msg.DoubleSpender.PushData = make([][]byte, numDoubleSpenderPushDatas)
+
+	for i := 0; i < int(numDoubleSpenderPushDatas); i++ {
+		msg.DoubleSpender.PushData[i], err = ReadVarBytes(r, pver, 512,
+			"Double spender push data")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BchEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgDSProof) BchEncode(w io.Writer, pver uint32, enc MessageEncoding) error {
+	if pver < DoubleSpendProofVersion {
+		str := fmt.Sprintf("dsproof message invalid for protocol "+
+			"version %d", pver)
+		return messageError("MsgDSProof.BchDecode", str)
+	}
+
+	err := writeElements(w,
+		&msg.TxInPrevHash,
+		msg.TxInPrevIndex,
+		msg.FirstSpender.Version,
+		msg.FirstSpender.Sequence,
+		msg.FirstSpender.LockTime,
+		&msg.FirstSpender.HashPrevOutputs,
+		&msg.FirstSpender.HashSequence,
+		&msg.FirstSpender.HashOutputs,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := WriteVarInt(w, pver, uint64(len(msg.FirstSpender.PushData))); err != nil {
+		return err
+	}
+
+	for _, elem := range msg.FirstSpender.PushData {
+		if err := WriteVarBytes(w, pver, elem); err != nil {
+			return err
+		}
+	}
+	err = writeElements(w,
+		msg.DoubleSpender.Version,
+		msg.DoubleSpender.Sequence,
+		msg.DoubleSpender.LockTime,
+		&msg.DoubleSpender.HashPrevOutputs,
+		&msg.DoubleSpender.HashSequence,
+		&msg.DoubleSpender.HashOutputs,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := WriteVarInt(w, pver, uint64(len(msg.DoubleSpender.PushData))); err != nil {
+		return err
+	}
+
+	for _, elem := range msg.DoubleSpender.PushData {
+		if err := WriteVarBytes(w, pver, elem); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ProofHash generates the Hash for the message.
+func (msg *MsgDSProof) ProofHash() chainhash.Hash {
+	// Encode the proof and calculate double sha256 on the result.
+	// Ignore the error returns since the only way the encode could fail
+	// is being out of memory or due to nil pointers, both of which would
+	// cause a run-time panic.
+	var buf bytes.Buffer
+	msg.BchEncode(&buf, ProtocolVersion, BaseEncoding)
+	return chainhash.DoubleHashH(buf.Bytes())
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgDSProof) Command() string {
+	return CmdDSProof
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgDSProof) MaxPayloadLength(pver uint32) uint32 {
+	// 32 + 4 + (2 * (4 + 4 + 4 + 32 + 32 + 32 + 9 + txscript.MaxScriptSize))
+	return 20270
+}
+
+// NewMsgDSProof returns a new bitcoin MsgDSProof message that conforms to the
+// Message interface using the passed parameters and defaults for the remaining
+// fields.
+func NewMsgDSProof(outpoint OutPoint, firstSpender Spender, doubleSpender Spender) *MsgDSProof {
+	return &MsgDSProof{
+		TxInPrevHash:  outpoint.Hash,
+		TxInPrevIndex: outpoint.Index,
+		FirstSpender:  firstSpender,
+		DoubleSpender: doubleSpender,
+	}
+}

--- a/wire/msgdsproof_test.go
+++ b/wire/msgdsproof_test.go
@@ -1,0 +1,208 @@
+package wire
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"github.com/davecgh/go-spew/spew"
+	"reflect"
+	"testing"
+)
+
+// TestDSProof tests the MsgDSProof API against the latest protocol
+// version.
+func TestDSProof(t *testing.T) {
+	pver := ProtocolVersion
+	enc := BaseEncoding
+
+	// Ensure the command is expected value.
+	wantCmd := "dsproof-beta"
+	msg := NewMsgDSProof(OutPoint{}, Spender{}, Spender{})
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("NewMsgDSProof: wrong command - got %v want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload is expected value.
+	wantPayload := uint32(20270)
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Test encode with latest protocol version.
+	var buf bytes.Buffer
+	err := msg.BchEncode(&buf, pver, enc)
+	if err != nil {
+		t.Errorf("encode of MsgDSProof failed %v err <%v>", msg,
+			err)
+	}
+
+	// Older protocol versions should fail encode since message didn't
+	// exist yet.
+	oldPver := DoubleSpendProofVersion - 1
+	err = msg.BchEncode(&buf, oldPver, enc)
+	if err == nil {
+		s := "encode of MsgDSProof passed for old protocol " +
+			"version %v err <%v>"
+		t.Errorf(s, msg, err)
+	}
+
+	// Test decode with latest protocol version.
+	readmsg := MsgDSProof{}
+	err = readmsg.BchDecode(&buf, pver, enc)
+	if err != nil {
+		t.Errorf("decode of MsgDSProof failed [%v] err <%v>", buf,
+			err)
+	}
+
+	// Older protocol versions should fail decode since message didn't
+	// exist yet.
+	err = readmsg.BchDecode(&buf, oldPver, enc)
+	if err == nil {
+		s := "decode of MsgDSProof passed for old protocol " +
+			"version %v err <%v>"
+		t.Errorf(s, msg, err)
+	}
+}
+
+// TestDSProofVersion tests the MsgDSProof API against the protocol
+// prior to version NoValidationRelayVersion.
+func TestDSProofVersion(t *testing.T) {
+	// Use the protocol version just prior to BIP0152Version changes.
+	pver := NoValidationRelayVersion - 1
+	enc := BaseEncoding
+
+	msg := NewMsgDSProof(OutPoint{}, Spender{}, Spender{})
+
+	// Test encode with old protocol version.
+	var buf bytes.Buffer
+	err := msg.BchEncode(&buf, pver, enc)
+	if err == nil {
+		t.Errorf("encode of MsgDSProof succeeded when it should " +
+			"have failed")
+	}
+
+	// Test decode with old protocol version.
+	readmsg := MsgDSProof{}
+	err = readmsg.BchDecode(&buf, pver, enc)
+	if err == nil {
+		t.Errorf("decode of MsgDSProof succeeded when it should " +
+			"have failed")
+	}
+}
+
+// TestDSProofCrossProtocol tests the MsgDSProof API when encoding with
+// the latest protocol version and decoding with BIP0152Version.
+func TestDSProofCrossProtocol(t *testing.T) {
+	enc := BaseEncoding
+	msg := NewMsgDSProof(OutPoint{}, Spender{}, Spender{})
+
+	// Encode with latest protocol version.
+	var buf bytes.Buffer
+	err := msg.BchEncode(&buf, ProtocolVersion, enc)
+	if err != nil {
+		t.Errorf("encode of MsgDSProof succeeded when it should failed %v err <%v>", msg,
+			err)
+	}
+	for _, b := range buf.Bytes() {
+		fmt.Print("0x" + hex.EncodeToString([]byte{b}) + ", ")
+	}
+
+	// Decode with old protocol version.
+	readmsg := MsgDSProof{}
+	err = readmsg.BchDecode(&buf, BIP0152Version, enc)
+	if err == nil {
+		t.Errorf("decode of MsgDSProof failed [%v] err <%v>", buf,
+			err)
+	}
+}
+
+// TestDSProofWire tests the MsgDSProofWire wire encode and decode for
+// various protocol versions.
+func TestDSProofWire(t *testing.T) {
+	msgSendCmpct := NewMsgDSProof(OutPoint{Index: 1}, Spender{PushData: make([][]byte, 0)}, Spender{PushData: make([][]byte, 0)})
+	msgSendCmpctEncoded := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00}
+
+	tests := []struct {
+		in   *MsgDSProof     // Message to encode
+		out  *MsgDSProof     // Expected decoded message
+		buf  []byte          // Wire encoding
+		pver uint32          // Protocol version for wire encoding
+		enc  MessageEncoding // Message encoding format
+	}{
+		// Latest protocol version.
+		{
+			msgSendCmpct,
+			msgSendCmpct,
+			msgSendCmpctEncoded,
+			ProtocolVersion,
+			BaseEncoding,
+		},
+
+		// Protocol version DoubleSpendProofVersion+1
+		{
+			msgSendCmpct,
+			msgSendCmpct,
+			msgSendCmpctEncoded,
+			DoubleSpendProofVersion + 1,
+			BaseEncoding,
+		},
+
+		// Protocol version DoubleSpendProofVersion
+		{
+			msgSendCmpct,
+			msgSendCmpct,
+			msgSendCmpctEncoded,
+			DoubleSpendProofVersion,
+			BaseEncoding,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BchEncode(&buf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BchEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BchEncode #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg MsgDSProof
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BchDecode(rbuf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BchDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, test.out) {
+			t.Errorf("BchDecode #%d\n got: %s want: %s", i,
+				spew.Sdump(msg), spew.Sdump(test.out))
+			continue
+		}
+	}
+}

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -13,7 +13,7 @@ import (
 // XXX pedro: we will probably need to bump this.
 const (
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 70015
+	ProtocolVersion uint32 = 70016
 
 	// MultipleAddressVersion is the protocol version which added multiple
 	// addresses per message (pver >= MultipleAddressVersion).
@@ -61,6 +61,11 @@ const (
 	// accept compact block relay but pledge not to ban nodes which
 	// relay blocks without validating them first.
 	NoValidationRelayVersion uint32 = 70015
+
+	// DoubleSpendProofVersion is the prootocol version which added
+	// double spend proof relaying.
+	// FIXME: What is this supposed to be?
+	DoubleSpendProofVersion uint32 = 70016
 )
 
 // ServiceFlag identifies services supported by a bitcoin peer.


### PR DESCRIPTION
Spec: https://gitlab.com/-/snippets/1883331

TODO:

- [x] Validate proof.

- [ ] Send proof to RPC server and gRPC server.

- [ ] RPC servers handle dsproof subscriptions. On subscribe should scan mempool to see if any proofs exist. Relay if so.

- [x] FetchDSProof mempool method.

- [x] Remove dsproofs from mempool on confirmation.

- [x] Generate dsproofs when double spend is detected.

- [x] Handle orphan proofs.