### PR TITLE
[Feature] Select new sync peer if median of sync peer candidates are ahead of us

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -571,7 +571,12 @@ func (sm *SyncManager) medianSyncPeerCandidateBlockHeight() int32 {
 			continue
 		}
 
-		heights = append(heights, peer.LastBlock())
+		topBlock := peer.LastBlock()
+		if topBlock < peer.StartingHeight() {
+			topBlock = peer.StartingHeight()
+		}
+
+		heights = append(heights, topBlock)
 	}
 
 	// If we don't have any sync peer candidate heights, return 0.

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -29,6 +29,11 @@ const (
 	// more.
 	minInFlightBlocks = 10
 
+	// minSyncPeerMedianHeights is the minimum number of valid sync
+	// peer candidates to trust for updating the sync peer due
+	// to it being behind.
+	minSyncPeerMedianHeights = 5
+
 	// maxNetworkViolations is the max number of network violations a
 	// sync peer can have before a new sync peer is found.
 	maxNetworkViolations = 3
@@ -579,9 +584,9 @@ func (sm *SyncManager) medianSyncPeerCandidateBlockHeight() int32 {
 		heights = append(heights, topBlock)
 	}
 
-	// If we don't have any sync peer candidate heights, return 0.
-	// This is just to protect from a panic below.
-	if len(heights) < 1 {
+	// Make sure we have enough heights to trust the data.
+	// If we only have 1 or 2 that could be gamed easily!
+	if len(heights) < minSyncPeerMedianHeights {
 		return 0
 	}
 


### PR DESCRIPTION
Had a stall on bchd.greyh.at that caused the node to fall behind. It was stuck on a sync peer that was behind other peers and somehow didn't realize it was a bad peer.

I have added logic that if a majority of sync peer candidates are ahead of us, then we should probably select a new peer!