### PR TITLE
Remove ScriptVerifyMinimalIf from StandardVerifyFlags

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -30,7 +30,6 @@ const (
 		ScriptVerifyDERSignatures |
 		ScriptVerifyStrictEncoding |
 		ScriptVerifyMinimalData |
-		ScriptVerifyMinimalIf |
 		ScriptStrictMultiSig |
 		ScriptDiscourageUpgradableNops |
 		ScriptVerifyCleanStack |


### PR DESCRIPTION
ABC does not enforce this rule neither in the standard nor mandatory flags.

https://github.com/Bitcoin-ABC/bitcoin-abc/search?q=SCRIPT_VERIFY_MINIMALIF&unscoped_q=SCRIPT_VERIFY_MINIMALIF

Not sure if this requires any tests.
