### PR TITLE
Fix seeds list after hard fork

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -243,9 +243,10 @@ var MainNetParams = Params{
 	DefaultPort: "8333",
 	DNSSeeds: []DNSSeed{
 		{"seed.bchd.cash", true},
-		{"seed.bitcoinabc.org", true},
 		{"btccash-seeder.bitcoinunlimited.info", true},
 		{"seed-bch.bitcoinforks.org", true},
+		{"seed.bch.loping.net", true},
+		{"dnsseed.electroncash.de", true},
 	},
 
 	// Chain parameters
@@ -474,8 +475,8 @@ var TestNet3Params = Params{
 	DefaultPort: "18333",
 	DNSSeeds: []DNSSeed{
 		{"testnet-seed.bchd.cash", true},
-		{"testnet-seed.bitcoinabc.org", true},
 		{"testnet-seed-bch.bitcoinforks.org", true},
+		{"seed.tbch.loping.net", true},
 	},
 
 	// Chain parameters

--- a/chaincfg/params_test.go
+++ b/chaincfg/params_test.go
@@ -38,9 +38,10 @@ func TestMustRegisterPanic(t *testing.T) {
 func TestMainNetSeeds(t *testing.T) {
 	expectedSeeds := []DNSSeed{
 		{"seed.bchd.cash", true},
-		{"seed.bitcoinabc.org", true},
 		{"btccash-seeder.bitcoinunlimited.info", true},
 		{"seed-bch.bitcoinforks.org", true},
+		{"seed.bch.loping.net", true},
+		{"dnsseed.electroncash.de", true},
 	}
 
 	if MainNetParams.DNSSeeds == nil {
@@ -65,8 +66,8 @@ func TestMainNetSeeds(t *testing.T) {
 func TestTestNet3Seeds(t *testing.T) {
 	expectedSeeds := []DNSSeed{
 		{"testnet-seed.bchd.cash", true},
-		{"testnet-seed.bitcoinabc.org", true},
 		{"testnet-seed-bch.bitcoinforks.org", true},
+		{"seed.tbch.loping.net", true},
 	}
 
 	if TestNet3Params.DNSSeeds == nil {


### PR DESCRIPTION
Remove one invalid seed now serving peers from another network. Add two new seeds to replace it on mainnet, and one for testnet.