### PR TITLE
[Bug] Return pubkey outputs in pb.bchrpc.GetAddressUnspentOutputs

### DIFF
--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -929,7 +929,17 @@ func (s *GrpcServer) GetAddressUnspentOutputs(ctx context.Context, req *pb.GetAd
 				continue
 			}
 
-			if addrs[0].EncodeAddress() == addr.EncodeAddress() {
+			matchAddr := ""
+
+			switch typedAddr := addrs[0].(type) {
+			case *bchutil.AddressPubKeyHash, *bchutil.AddressScriptHash:
+				matchAddr = addrs[0].EncodeAddress()
+
+			case *bchutil.AddressPubKey:
+				matchAddr = typedAddr.AddressPubKeyHash().EncodeAddress()
+			}
+
+			if matchAddr == addr.EncodeAddress() {
 				utxo := &pb.UnspentOutput{
 					Outpoint: &pb.Transaction_Input_Outpoint{
 						Hash:  txHash.CloneBytes(),


### PR DESCRIPTION
Fixes https://github.com/gcash/bchd/issues/414