### PR TITLE
[Bug] Print error and exit if indexing and running a pruned node

### DIFF
--- a/config.go
+++ b/config.go
@@ -613,6 +613,15 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
+	// Indexing doesn't work with a pruned blockchain.
+	if (cfg.TxIndex || cfg.AddrIndex) && cfg.Prune {
+		str := "%s: txindex and addrindex can not be used with a pruned blockchain."
+		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, usageMessage)
+		return nil, nil, err
+	}
+
 	// Indexing also doesn't work with fast sync as the indexes will not go
 	// back to genesis.
 	if (cfg.TxIndex || cfg.AddrIndex) && cfg.FastSync {


### PR DESCRIPTION
Fixes https://github.com/gcash/bchd/issues/412 by making sure you can't run indexes on a pruned node.

Whoever picks up https://github.com/gcash/bchd/issues/302 can remove this small patch.