### PR TITLE
[Bug] Fix panic in fee estimator from reorgs

### DIFF
--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -273,9 +273,10 @@ func (ef *FeeEstimator) RegisterBlock(block *bchutil.Block) error {
 			return errors.New("Transaction has already been mined")
 		}
 
-		// This shouldn't happen but check just in case to avoid
-		// an out-of-bounds array index later.
-		if blocksToConfirm >= estimateFeeDepth {
+		// This shouldn't happen in normal operation but check just in case
+		// to avoid an out-of-bounds array index later. Make sure to cover
+		// negative indexes in the case of reorgs.
+		if blocksToConfirm >= estimateFeeDepth || blocksToConfirm < 0 {
 			continue
 		}
 


### PR DESCRIPTION
Quick fix based on the conversation at https://github.com/btcsuite/btcd/issues/1660.

Basically the cause of the double unlock is not really a mutex issue, but a defer issue due to an out of index panic in the fee estimator. This just puts a guard on the index value. When a more robust fix is available we can use that, but with BCH we don't really need a fee estimator to be perfect. =)