### PR TITLE
Check for server shutdown in gRPC GetAddressUnspentOutputs

### DIFF
--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -962,6 +962,9 @@ func (s *GrpcServer) GetAddressUnspentOutputs(ctx context.Context, req *pb.GetAd
 		fetch = 10000
 	)
 	for {
+		if atomic.LoadInt32(&s.shutdown) > 0 {
+			return nil, status.Error(codes.Canceled, "canceled by server")
+		}
 		confirmedTxs, err := s.fetchTransactionsByAddress(addr, 0, fetch, skip)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
GetAddressUnspentOutputs can really hammer the server if an address is passed
in with a very large transaction history.

This adds a shutdown check every time through the loop which will terminate
the RPC call if a shutdown is requested while the RPC call is still processing.