### PR TITLE
[Bug] Add shutdown check to updateSyncPeer

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -653,6 +653,11 @@ func (sm *SyncManager) clearRequestedState(state *peerSyncState) {
 
 // updateSyncPeer picks a new peer to sync from.
 func (sm *SyncManager) updateSyncPeer() {
+	// Ignore if we are shutting down.
+	if atomic.LoadInt32(&sm.shutdown) != 0 {
+		return
+	}
+
 	if sm.syncPeer != nil {
 		state, exists := sm.peerStates[sm.syncPeer]
 		if exists {


### PR DESCRIPTION
When shutting down the peer manager would try to select a new sync peer when it didn't need to. This just adds a shutdown check to make sure that doesn't happen.

Before:

```
Jan 26 21:30:52 alucard bchd[416498]: 2021-01-26 21:30:52.281 [INF] SYNC: Sync manager shutting down
Jan 26 21:30:52 alucard bchd[416498]: 2021-01-26 21:30:52.281 [INF] SYNC: Updating sync peer, last block: 2021-01-26 21:30:22.941960491 -1000 HST m=+31.269384516, violations: 0
Jan 26 21:30:52 alucard bchd[416498]: 2021-01-26 21:30:52.281 [WRN] SYNC: No sync peer candidates available
Jan 26 21:30:52 alucard bchd[416498]: 2021-01-26 21:30:52.281 [INF] CHAN: Flushing UTXO cache of ~1 MiB to disk. For large sizes, this can take up to several minutes...
Jan 26 21:30:52 alucard bchd[416498]: 2021-01-26 21:30:52.285 [INF] AMGR: Address manager shutting down
Jan 26 21:30:52 alucard bchd[416498]: 2021-01-26 21:30:52.314 [INF] SRVR: Server shutdown complete
Jan 26 21:30:52 alucard bchd[416498]: 2021-01-26 21:30:52.315 [INF] BCHD: Gracefully shutting down the database...
Jan 26 21:30:52 alucard bchd[416498]: 2021-01-26 21:30:52.370 [INF] BCHD: Shutdown complete
```

After

```
Jan 26 21:32:45 alucard bchd[418811]: 2021-01-26 21:32:45.542 [INF] SYNC: Sync manager shutting down
Jan 26 21:32:45 alucard bchd[418811]: 2021-01-26 21:32:45.542 [INF] CHAN: Flushing UTXO cache of ~1 MiB to disk. For large sizes, this can take up to several minutes...
Jan 26 21:32:45 alucard bchd[418811]: 2021-01-26 21:32:45.551 [INF] AMGR: Address manager shutting down
Jan 26 21:32:45 alucard bchd[418811]: 2021-01-26 21:32:45.603 [INF] SRVR: Server shutdown complete
Jan 26 21:32:45 alucard bchd[418811]: 2021-01-26 21:32:45.603 [INF] BCHD: Gracefully shutting down the database...
Jan 26 21:32:45 alucard bchd[418811]: 2021-01-26 21:32:45.681 [INF] BCHD: Shutdown complete
```