### PR TITLE
Serialize outgoing peer requests

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -183,6 +183,8 @@ type ConnManager struct {
 	failedAttempts uint64
 	requests       chan interface{}
 	quit           chan struct{}
+
+	sync.Mutex
 }
 
 // handleFailedConn handles a connection failed due to a disconnect or any
@@ -358,7 +360,13 @@ out:
 
 // NewConnReq creates a new connection request and connects to the
 // corresponding address.
+//
+// Since this method is called many times via goroutine a lock is used
+// to serialize those calls and reduce duplicate connections.
 func (cm *ConnManager) NewConnReq() {
+	cm.Lock()
+	defer cm.Unlock()
+
 	if atomic.LoadInt32(&cm.stop) != 0 {
 		return
 	}


### PR DESCRIPTION
We noticed on a testnet with 1 or 2 other available peers the node would make many (up to 8) connection requests to the same peer. This resulted in our node getting banned by the other peers because of the spamming.

Simply serializing the call for NewConnReq significantly reduces duplicate connections. Sometimes we still see a duplicate connection on startup, probably due to some race condition in the call cm.cfg.GetNewAddress.

This fixes the startup related issue https://github.com/gcash/bchd/issues/448, and may also fix https://github.com/gcash/bchd/pull/296 but not sure the entire context for this PR.