### PR TITLE
Experimental WIP: update cache strategy in utxocache.go

### DIFF
--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -222,7 +222,7 @@ type utxoCache struct {
 func newUtxoCache(db database.DB, maxTotalMemoryUsage uint64) *utxoCache {
 	return &utxoCache{
 		db:            db,
-		cachedEntries: gcache.New(int(maxTotalMemoryUsage) / 36).LRU().Build(),
+		cachedEntries: gcache.New(int(maxTotalMemoryUsage) / 36).Simple().Build(),
 	}
 }
 


### PR DESCRIPTION
During IBD/indexing I noticed the utxo cache builds up to max size then flushes to disk and is cleared to zero, each time this flush happens processing is halted for several minutes.  I'm guessing the cache needs to go to zero since its just a simple `map[wire.Outpoint]*UtxoEntry`, which has no eviction policy obviously.

So I just wanted to try to use LRU cache (edit: FIFO cache is more ideal, will update this later) to avoid these long delays in flushing, and just evict the oldest items from cache once the cache reaches its maximum size.  This would allow the cache size to remain at its capacity.

**Questions I have**

* Does the UTXO DB updates depend on the periodic UTXO cache flushing?  If so, then this PR would need to be updated to add some DB commit whenever an item gets evicted from the LRU cache.
* gcache is concurrent safe, but still need to confirm that removing the mutex lock in all places is safe. Do we still want to keep the lock on `Flush()`?
* Any other implications that I'm missing?
* What are the measured performance differences between the two cache types?
