### PR TITLE
gRPC server: fix possible race condition

### DIFF
--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -204,8 +204,8 @@ func (s *GrpcServer) subscribeEvents() *rpcEventSubscription {
 
 	// Start a queue handler for the subscription so that slow connections don't
 	// hold up faster ones.
+	s.wg.Add(1)
 	go func() {
-		s.wg.Add(1)
 		queueHandler(sub.in, sub.out, s.quit)
 		s.wg.Done()
 	}()


### PR DESCRIPTION
I doubt we would be impacted by this, but figured its still worth fixing. 

Noticed this after go-staticcheck provided:
`should call s.wg.Add(1) before starting the goroutine to avoid a race (SA2000)`