### PR TITLE
Minor nits and slpindex cleanup

### DIFF
--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -1384,6 +1384,9 @@ func (s *GrpcServer) GetSlpTrustedValidation(ctx context.Context, req *pb.GetSlp
 		}
 
 		slpMsg, err := v1parser.ParseSLP(entry.SlpOpReturn)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "could not parse existing entry slp metadata scriptPubKey %s", hex.EncodeToString(entry.SlpOpReturn))
+		}
 
 		// set the proper slp version type
 		switch slpMsg.TokenType() {

--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -2848,8 +2848,6 @@ func (s *GrpcServer) slpEventHandler() {
 			s.checkSlpTxOnEvent(txDesc.Tx.MsgTx(), "mempool")
 			continue
 		case *rpcEventBlockConnected:
-			block := event
-			s.slpIndex.RemoveMempoolSlpTxs(block.Transactions())
 			continue
 		}
 	}

--- a/bchrpc/txfilter.go
+++ b/bchrpc/txfilter.go
@@ -165,7 +165,7 @@ func (f *txFilter) AddRPCFilter(rpcFilter *pb.TransactionFilter, params *chaincf
 	for _, addrStr := range rpcFilter.GetAddresses() {
 		addr, err := bchutil.DecodeAddress(addrStr, params)
 		if err != nil {
-			return fmt.Errorf("Unable to decode address '%v': %v", addrStr, err)
+			return fmt.Errorf("unable to decode address '%v': %v", addrStr, err)
 		}
 		f.AddAddress(addr)
 	}

--- a/blockchain/indexers/slpindex.go
+++ b/blockchain/indexers/slpindex.go
@@ -578,6 +578,9 @@ func (idx *SlpIndex) ConnectBlock(dbTx database.Tx, block *bchutil.Block, stxos 
 		}
 	}
 
+	// Remove block transactions from the slp mempool cache
+	idx.removeMempoolSlpTxs(block.Transactions())
+
 	// Loop through burned inputs and check for different situations
 	// where token metadata will need to be updated.
 	//
@@ -959,9 +962,9 @@ func (idx *SlpIndex) AddPotentialSlpEntries(dbTx database.Tx, msgTx *wire.MsgTx)
 	return valid, err
 }
 
-// RemoveMempoolSlpTxs removes a list of transactions from the temporary cache that holds
+// removeMempoolSlpTxs removes a list of transactions from the temporary cache that holds
 // both mempool and recently queried SlpIndexEntries
-func (idx *SlpIndex) RemoveMempoolSlpTxs(txs []*bchutil.Tx) {
+func (idx *SlpIndex) removeMempoolSlpTxs(txs []*bchutil.Tx) {
 	idx.cache.RemoveMempoolSlpTxItems(txs)
 }
 

--- a/blockchain/indexers/slpindex.go
+++ b/blockchain/indexers/slpindex.go
@@ -677,6 +677,9 @@ func CheckSlpTx(tx *wire.MsgTx, getSlpIndexEntry GetSlpIndexEntryHandler, putTxI
 		prevIdx := int(txi.PreviousOutPoint.Index)
 
 		slpEntry, err := getSlpIndexEntry(&txi.PreviousOutPoint.Hash)
+		if err != nil {
+			log.Tracef("no slp input entry for %v, %v", txi.PreviousOutPoint.Hash, err)
+		}
 		if slpEntry == nil {
 			continue
 		}
@@ -933,6 +936,9 @@ func (idx *SlpIndex) AddPotentialSlpEntries(dbTx database.Tx, msgTx *wire.MsgTx)
 			err := idx.db.View(func(dbTx database.Tx) error {
 				hash := tx.TxHash()
 				entry, err := idx.GetSlpIndexEntry(dbTx, &hash)
+				if err != nil {
+					return fmt.Errorf("could not retreive token entry for mint txn %v: %v", hash, err)
+				}
 				tm, err := idx.GetTokenMetadata(dbTx, entry)
 				if err != nil {
 					return fmt.Errorf("could not retreive token metadata for mint txn %v: %v", hash, err)
@@ -1055,16 +1061,4 @@ func TopologicallySortTxs(transactions []*bchutil.Tx) []*wire.MsgTx {
 		}
 	}
 	return sorted
-}
-
-func removeDups(txs []*wire.MsgTx) []*wire.MsgTx {
-	keys := make(map[*wire.MsgTx]bool)
-	var ret []*wire.MsgTx
-	for _, tx := range txs {
-		if _, ok := keys[tx]; !ok {
-			keys[tx] = true
-			ret = append(ret, tx)
-		}
-	}
-	return ret
 }

--- a/blockchain/indexers/slpindex_test.go
+++ b/blockchain/indexers/slpindex_test.go
@@ -27,6 +27,9 @@ func TestSlpInputUnitTests(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	data, err := ioutil.ReadAll(inputTestsFile)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	defer inputTestsFile.Close()
 
 	type TxItem struct {
@@ -71,6 +74,9 @@ func TestSlpInputUnitTests(t *testing.T) {
 				continue
 			}
 			tokenID, err := goslp.GetSlpTokenID(tx)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
 			tokenIDHash, err := chainhash.NewHash(tokenID[:])
 			if err != nil {
 				t.Fatal(err.Error())
@@ -114,7 +120,10 @@ func TestSlpInputUnitTests(t *testing.T) {
 		}
 
 		// check the slp txns
-		isValid, _, _ := indexers.CheckSlpTx(tx, getSlpIndexEntry, putTxIndexEntry)
+		isValid, _, err := indexers.CheckSlpTx(tx, getSlpIndexEntry, putTxIndexEntry)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
 		if isValid != test.Should[0].Valid {
 			t.Errorf("Test %d: Expected valid = %t, got %t, \n%s", i, test.Should[0].Valid, isValid, test.Description)
 		}


### PR DESCRIPTION
The main thing here is the first commit making RemoveMempoolSlpTxs a private function and moving the call to the end of ConnectBlock.  The second commit is just minor things detected by go-staticcheck,