### PR TITLE
fix race condition in addrmanager_internal_test

### DIFF
--- a/addrmgr/addrmanager_internal_test.go
+++ b/addrmgr/addrmanager_internal_test.go
@@ -81,7 +81,6 @@ func assertAddrs(t *testing.T, addrMgr *AddrManager,
 // TestAddrManagerSerialization ensures that we can properly serialize and
 // deserialize the manager's current address cache.
 func TestAddrManagerSerialization(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by creating our address manager backed by a temporary
 	// directory.
@@ -121,7 +120,6 @@ func TestAddrManagerSerialization(t *testing.T) {
 // TestAddrManagerV1ToV2 ensures that we can properly upgrade the serialized
 // version of the address manager from v1 to v2.
 func TestAddrManagerV1ToV2(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by creating our address manager backed by a temporary
 	// directory.


### PR DESCRIPTION
Travis CI tests were failing sometimes because of this...

Two tests running in parallel reading and writing to the same file
creates a race condition that causes one of the tests to fail sometimes.

Chose to remove t.Parallel() in lieu of changing the temp file name
of one tests since other tests don't use t.Parallel() and the tests
should stand alone from each other.