### PR TITLE
Peer/sync manager improvements

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -329,6 +329,9 @@ func (sm *SyncManager) startSync() {
 	bestPeers := []*peerpkg.Peer{}
 	okPeers := []*peerpkg.Peer{}
 	for peer, state := range sm.peerStates {
+		// Check if this node is a sync candidate. These nodes will be used
+		// when determining switching sync peers.  See 'medianSyncPeerCandidateBlockHeight'.
+		state.syncCandidate = sm.isSyncCandidate(peer)
 		if !state.syncCandidate {
 			continue
 		}


### PR DESCRIPTION
There are two improvements here for the peer manager.

The first commit fixes an issue where in regtest mode bchd wouldn't connect to some other nodes that don't advertise full node service in while in regtest mode.  This behavior was already baked in, but it was broken by my previous commit 9392a9 adding `sm.regTestSyncAnyHost`.

The second commit addresses an issue where some peers may become valid sync peers but the peer's `syncCandidate` is stuck at false because at some time their block height was less than ours (see manager.go new line 354).