### PR TITLE
[Chore] Guard against nil buckets to prevent panics

### DIFF
--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -2929,7 +2929,7 @@ func (s *GrpcServer) getSlpToken(hash *chainhash.Hash, vout uint32, scriptPubKey
 // NOTE: this is launched as a goroutine and does not return errors!
 //
 func (s *GrpcServer) slpEventHandler() {
-	if s.slpIndex == nil || s.txIndex == nil {
+	if s.slpIndex == nil {
 		return
 	}
 

--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -2929,8 +2929,7 @@ func (s *GrpcServer) getSlpToken(hash *chainhash.Hash, vout uint32, scriptPubKey
 // NOTE: this is launched as a goroutine and does not return errors!
 //
 func (s *GrpcServer) slpEventHandler() {
-
-	if s.slpIndex == nil {
+	if s.slpIndex == nil || s.txIndex == nil {
 		return
 	}
 

--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -735,6 +735,9 @@ func (idx *AddrIndex) ConnectBlock(dbTx database.Tx, block *bchutil.Block,
 
 	// Add all of the index entries for each address.
 	addrIdxBucket := dbTx.Metadata().Bucket(addrIndexKey)
+	if addrIdxBucket == nil {
+		return fmt.Errorf("bucket nil for key: %s", addrIndexKey)
+	}
 	for addrKey, txIdxs := range addrsToTxns {
 		for _, txIdx := range txIdxs {
 			err := dbPutAddrIndexEntry(addrIdxBucket, addrKey,
@@ -762,6 +765,9 @@ func (idx *AddrIndex) DisconnectBlock(dbTx database.Tx, block *bchutil.Block,
 
 	// Remove all of the index entries for each address.
 	bucket := dbTx.Metadata().Bucket(addrIndexKey)
+	if bucket == nil {
+		return fmt.Errorf("bucket nil for key: %s", addrIndexKey)
+	}
 	for addrKey, txIdxs := range addrsToTxns {
 		err := dbRemoveAddrIndexEntries(bucket, addrKey, len(txIdxs))
 		if err != nil {
@@ -801,6 +807,9 @@ func (idx *AddrIndex) TxRegionsForAddress(dbTx database.Tx, addr bchutil.Address
 
 		var err error
 		addrIdxBucket := dbTx.Metadata().Bucket(addrIndexKey)
+		if addrIdxBucket == nil {
+			return fmt.Errorf("bucket nil for key: %s", addrIndexKey)
+		}
 		regions, skipped, err = dbFetchAddrIndexEntries(addrIdxBucket,
 			addrKey, numToSkip, numRequested, reverse,
 			fetchBlockHash)

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -134,6 +134,9 @@ func dbRemoveBlockIDIndexEntry(dbTx database.Tx, hash *chainhash.Hash) error {
 // block id for the provided hash from the index.
 func dbFetchBlockIDByHash(dbTx database.Tx, hash *chainhash.Hash) (uint32, error) {
 	hashIndex := dbTx.Metadata().Bucket(idByHashIndexBucketName)
+	if hashIndex == nil {
+		return 0, fmt.Errorf("bucket nil for key: %s", idByHashIndexBucketName)
+	}
 	serializedID := hashIndex.Get(hash[:])
 	if serializedID == nil {
 		return 0, errNoBlockIDEntry
@@ -146,6 +149,9 @@ func dbFetchBlockIDByHash(dbTx database.Tx, hash *chainhash.Hash) (uint32, error
 // retrieve the hash for the provided serialized block id from the index.
 func dbFetchBlockHashBySerializedID(dbTx database.Tx, serializedID []byte) (*chainhash.Hash, error) {
 	idIndex := dbTx.Metadata().Bucket(hashByIDIndexBucketName)
+	if idIndex == nil {
+		return nil, fmt.Errorf("bucket nil for key: %s", hashByIDIndexBucketName)
+	}
 	hashBytes := idIndex.Get(serializedID)
 	if hashBytes == nil {
 		return nil, errNoBlockIDEntry
@@ -179,6 +185,9 @@ func putTxIndexEntry(target []byte, blockID uint32, txLoc wire.TxLoc) {
 // been serialized putTxIndexEntry.
 func dbPutTxIndexEntry(dbTx database.Tx, txHash *chainhash.Hash, serializedData []byte) error {
 	txIndex := dbTx.Metadata().Bucket(txIndexKey)
+	if txIndex == nil {
+		return fmt.Errorf("bucket nil for key: %s", txIndexKey)
+	}
 	return txIndex.Put(txHash[:], serializedData)
 }
 
@@ -189,6 +198,9 @@ func dbPutTxIndexEntry(dbTx database.Tx, txHash *chainhash.Hash, serializedData 
 func dbFetchTxIndexEntry(dbTx database.Tx, txHash *chainhash.Hash) (*database.BlockRegion, error) {
 	// Load the record from the database and return now if it doesn't exist.
 	txIndex := dbTx.Metadata().Bucket(txIndexKey)
+	if txIndex == nil {
+		return nil, fmt.Errorf("bucket nil for key: %s", txIndexKey)
+	}
 	serializedData := txIndex.Get(txHash[:])
 	if len(serializedData) == 0 {
 		return nil, nil
@@ -257,6 +269,9 @@ func dbAddTxIndexEntries(dbTx database.Tx, block *bchutil.Block, blockID uint32)
 // recent transaction index entry for the given hash.
 func dbRemoveTxIndexEntry(dbTx database.Tx, txHash *chainhash.Hash) error {
 	txIndex := dbTx.Metadata().Bucket(txIndexKey)
+	if txIndex == nil {
+		return fmt.Errorf("bucket nil for key: %s", txIndexKey)
+	}
 	serializedData := txIndex.Get(txHash[:])
 	if len(serializedData) == 0 {
 		return fmt.Errorf("can't remove non-existent transaction %s "+


### PR DESCRIPTION
Just adds checks to make sure a bucket is returned in our indexers. That way if we have an issue with a nil bucket, it will throw an error and not panic! The buckets should always be present, so returning an error is correct.

Mitigates https://github.com/gcash/bchd/issues/472
