### PR TITLE
Resolved consensus incompatibility regarding txscript.IsUnspendable

### DIFF
--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -161,11 +161,6 @@ func checkPkScriptStandard(pkScript []byte, scriptClass txscript.ScriptClass) er
 // particular, if the cost to the network to spend coins is more than 1/3 of the
 // minimum transaction relay fee, it is considered dust.
 func isDust(txOut *wire.TxOut, minRelayTxFee bchutil.Amount) bool {
-	// Unspendable outputs are considered dust.
-	if txscript.IsUnspendable(txOut.PkScript) {
-		return true
-	}
-
 	// The total serialized size consists of the output and the associated
 	// input script to redeem it.  Since there is no input script
 	// to redeem it yet, use the minimum size of a typical input script.
@@ -312,7 +307,7 @@ func checkTransactionStandard(tx *bchutil.Tx, height int32,
 		// "dust".
 		if scriptClass == txscript.NullDataTy {
 			dataCarrierSize += len(txOut.PkScript)
-		} else if isDust(txOut, minRelayTxFee) {
+		} else if txscript.IsUnspendable(txOut.PkScript) || isDust(txOut, minRelayTxFee) {
 			str := fmt.Sprintf("transaction output %d: payment "+
 				"of %d is dust", i, txOut.Value)
 			return txRuleError(wire.RejectDust, str)

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -258,14 +258,6 @@ func TestDust(t *testing.T) {
 			1<<63 - 1,
 			true,
 		},
-		{
-			// Unspendable pkScript due to an invalid public key
-			// script.
-			"unspendable pkScript",
-			wire.TxOut{Value: 5000, PkScript: []byte{0x01}},
-			0, // no relay fee
-			true,
-		},
 	}
 	for _, test := range tests {
 		res := isDust(&test.txOut, test.relayFee)
@@ -630,6 +622,23 @@ func TestCheckTransactionStandard(t *testing.T) {
 			},
 			height:     300000,
 			isStandard: true,
+			code:       wire.RejectNonstandard,
+		},
+		{
+			// Unspendable pkScript due to an invalid public key
+			// script.
+			name: "unspendable pkScript",
+			tx: wire.MsgTx{
+				Version: 1,
+				TxIn:    []*wire.TxIn{&dummyTxIn},
+				TxOut: []*wire.TxOut{{
+					Value:    5000,
+					PkScript: []byte{0x01},
+				}},
+				LockTime: 0,
+			},
+			height:     0, // no relay fee
+			isStandard: false,
 			code:       wire.RejectNonstandard,
 		},
 	}

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -629,14 +629,13 @@ func asSmallInt(op *opcode) int {
 	return int(op.value - (OP_1 - 1))
 }
 
-// IsUnspendable returns whether the passed public key script is unspendable, or
-// guaranteed to fail at execution.  This allows outputs to be pruned instantly
-// when entering the UTXO set.
+// IsUnspendable returns true if the passed public key script is provably
+// unspendable. Scripts may still be otherwise unspendable due to script
+// validation rules which this function intentionally does not account for
+// due to compatibility with other implementations. Provably unspendable
+// outputs are pruned instantly when entering the UTXO set.
 func IsUnspendable(pkScript []byte) bool {
-	pops, err := parseScript(pkScript)
-	if err != nil {
-		return true
-	}
-
-	return len(pops) > 0 && pops[0].opcode.value == OP_RETURN
+	scriptSize := len(pkScript)
+	return (scriptSize > 0 && pkScript[0] == OP_RETURN) ||
+		(scriptSize > MaxScriptSize)
 }


### PR DESCRIPTION
Other implementations of BCHD's txscript.IsUnspendable do not check for invalid op codes within the locking script.  Furthermore, invalid opcodes can technically become spendable in future hard forks, which could cause UTXO set corruption/incompatibility during a future upgrade if these opcodes were enabled and an already-synced node did not rebuild its UTXO set.

We discovered this discrepancy because this rule is also used when generating UTXO commitments, which makes BCHD's commitments otherwise incompatible with the (admittedly nebulous) utxo commitment specification.