### PR TITLE
FIX: OP_RETURN OP_1NEGATE is now considered a standard transaction.

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -164,6 +164,9 @@ func isNullData(pops []parsedOpcode) bool {
 			isDataOpcode = true
 			scriptLen += len(pop.data)
 			scriptLen += -pop.opcode.length + 1
+		} else if pop.opcode.value < OP_16 {
+			isDataOpcode = true
+			scriptLen++
 		}
 		if !isDataOpcode {
 			return false


### PR DESCRIPTION
Other implementations consider OP_1NEGATE a "push operation", and therefore is allowed after OP_RETURN when determining transaction standardness.

We also identified that the OP_RETURN "maxDataCarrierSize" calculation is inconsistent with other implementations.  Other implementations, and the BCH Multiple OpReturn Specification consider the max size to be the total size of the locking script, which includes opcodes (and is easier to calculate).  This PR does not resolve that issue.