### PR TITLE
added HTTPs support to gRPC proxy

### DIFF
--- a/bchrpc/proxy/README.md
+++ b/bchrpc/proxy/README.md
@@ -22,7 +22,7 @@ This will generate all of the files required for the gateway proxy and also the 
 
 ## Run the Proxy
 
-`$ ./gw -port 8080 -bchd-grpc-url <BCHD gRPC server url>:8335 -bchd-grpc-certpath <path to self-signed cert>`
+`$ ./gw -http-addr :8080 -bchd-grpc-url <BCHD gRPC server url>:8335 -bchd-grpc-certpath <path to self-signed cert>`
 
 If you are using a certificate signed by a CA then you do not need to specify a value for `-bchd-grpc-certpath`.
 

--- a/bchrpc/proxy/gw.go
+++ b/bchrpc/proxy/gw.go
@@ -96,7 +96,7 @@ func (proxy *GrpcProxy) serveHTTP(ctx context.Context) error {
 		WriteTimeout: 30 * time.Second,
 	}
 
-	if *useHTTPS == true {
+	if *useHTTPS {
 		fmt.Printf("Serving HTTPS at %s\n", *proxyAddr)
 		if err := proxy.server.ListenAndServeTLS(*httpsCert, *httpsKey); err != http.ErrServerClosed {
 			glog.Errorf("Error serving HTTP %+v", err)

--- a/bchrpc/proxy/gw_test.go
+++ b/bchrpc/proxy/gw_test.go
@@ -50,7 +50,18 @@ func TestMain(m *testing.M) {
 	}
 	go startLocalTestServer(proxy)
 	time.Sleep(1 * time.Second) // wait for HTTP server goroutine
-	httpClient, err = newHTTPClient(fmt.Sprintf("http://localhost:%s/v1/", *proxyPort), logRequestJSON)
+
+	// connect the HTTP test client to address:port
+	httpAddr := *proxyAddr
+	urlObj, err := url.Parse("http://" + httpAddr)
+	if err != nil {
+		log.Printf("Error parsing proxy backend address %s: %+v", httpAddr, err)
+		os.Exit(1)
+	}
+	if len(urlObj.Host) != 0 && urlObj.Host[0:1] == ":" {
+		httpAddr = "localhost" + httpAddr // only port specified -> use localhost
+	}
+	httpClient, err = newHTTPClient(fmt.Sprintf("http://%s/v1/", httpAddr), logRequestJSON)
 	if err != nil {
 		log.Printf("Error creating HTTP client: %+v", err)
 		os.Exit(1)


### PR DESCRIPTION
This PR:

- adds HTTPs support to the gRPC proxy. Currently all proxies run HTTPS using nginx and/or CloudFlare only. The default cert is `$HOME/.bchd/rpc.cert` (same as gRPC cert when running BCHD)
- renamed the `port` param to `http-addr` to be consistent with other HTTP params and allow binding to `address:port`