### PR TITLE
server: Actively prevent regnet network discovery

### DIFF
--- a/server.go
+++ b/server.go
@@ -508,7 +508,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 	isInbound := sp.Inbound()
 	remoteAddr := sp.NA()
 	addrManager := sp.server.addrManager
-	if !cfg.SimNet && !cfg.RegNet && !isInbound {
+	if !cfg.SimNet && !cfg.RegressionTest && !isInbound {
 		addrManager.SetServices(remoteAddr, msg.Services)
 	}
 
@@ -1546,7 +1546,7 @@ func (sp *serverPeer) OnGetAddr(_ *peer.Peer, msg *wire.MsgGetAddr) {
 	// test networks.  This helps prevent the networks from becoming another
 	// public test network since they will not be able to learn about other
 	// peers that have not specifically been provided.
-	if cfg.SimNet || cfg.RegNet {
+	if cfg.SimNet || cfg.RegressionTest {
 		return
 	}
 
@@ -1594,7 +1594,7 @@ func (sp *serverPeer) OnAddr(_ *peer.Peer, msg *wire.MsgAddr) {
 	// networks.  This helps prevent the networks from becoming another public
 	// test network since they will not be able to learn about other peers that
 	// have not specifically been provided.
-	if cfg.SimNet || cfg.RegNet {
+	if cfg.SimNet || cfg.RegressionTest {
 		return
 	}
 
@@ -2082,11 +2082,11 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 	s.syncManager.NewPeer(sp.Peer, nil)
 
 	// Update the address manager and request known addresses from the
-	// remote peer for outbound connections. This is skipped when running on
-	// the simulation test network since it is only intended to connect to
-	// specified peers and actively avoids advertising and connecting to
-	// discovered peers.
-	if !cfg.SimNet && !sp.Inbound() {
+	// remote peer for outbound connections. This is skipped when running
+	// on the simulation and regression test networks since they are only
+	// intended to connect to specified peers and actively avoid advertising
+	// and connecting to discovered peers.
+	if !cfg.SimNet && !cfg.RegressionTest && !sp.Inbound() {
 		// Advertise the local address when the server accepts incoming
 		// connections and it believes itself to be close to the best
 		// known tip.
@@ -3366,7 +3366,7 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string, db database
 	// discovered peers in order to prevent it from becoming a public test
 	// network.
 	var newAddressFunc func() (net.Addr, error)
-	if !cfg.SimNet && !cfg.RegNet && len(cfg.ConnectPeers) == 0 {
+	if !cfg.SimNet && !cfg.RegressionTest && len(cfg.ConnectPeers) == 0 {
 		newAddressFunc = func() (net.Addr, error) {
 			for tries := 0; tries < 100; tries++ {
 				addr := s.addrManager.GetAddress()

--- a/server.go
+++ b/server.go
@@ -498,9 +498,9 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 	// Update the address manager with the advertised services for outbound
 	// connections in case they have changed.  This is not done for inbound
 	// connections to help prevent malicious behavior and is skipped when
-	// running on the simulation test network since it is only intended to
-	// connect to specified peers and actively avoids advertising and
-	// connecting to discovered peers.
+	// running on the simulation and regression test networks since they are
+	// only intended to connect to specified peers and actively avoid
+	// advertising and connecting to discovered peers.
 	//
 	// NOTE: This is done before rejecting peers that are too old to ensure
 	// it is updated regardless in the case a new minimum protocol version is
@@ -508,7 +508,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 	isInbound := sp.Inbound()
 	remoteAddr := sp.NA()
 	addrManager := sp.server.addrManager
-	if !cfg.SimNet && !isInbound {
+	if !cfg.SimNet && !cfg.RegNet && !isInbound {
 		addrManager.SetServices(remoteAddr, msg.Services)
 	}
 
@@ -1542,11 +1542,11 @@ func (sp *serverPeer) OnFilterLoad(_ *peer.Peer, msg *wire.MsgFilterLoad) {
 // and is used to provide the peer with known addresses from the address
 // manager.
 func (sp *serverPeer) OnGetAddr(_ *peer.Peer, msg *wire.MsgGetAddr) {
-	// Don't return any addresses when running on the simulation test
-	// network.  This helps prevent the network from becoming another
-	// public test network since it will not be able to learn about other
+	// Don't return any addresses when running on the simulation and regression
+	// test networks.  This helps prevent the networks from becoming another
+	// public test network since they will not be able to learn about other
 	// peers that have not specifically been provided.
-	if cfg.SimNet {
+	if cfg.SimNet || cfg.RegNet {
 		return
 	}
 
@@ -1590,11 +1590,11 @@ func (sp *serverPeer) OnGetAddr(_ *peer.Peer, msg *wire.MsgGetAddr) {
 // OnAddr is invoked when a peer receives an addr bitcoin message and is
 // used to notify the server about advertised addresses.
 func (sp *serverPeer) OnAddr(_ *peer.Peer, msg *wire.MsgAddr) {
-	// Ignore addresses when running on the simulation test network.  This
-	// helps prevent the network from becoming another public test network
-	// since it will not be able to learn about other peers that have not
-	// specifically been provided.
-	if cfg.SimNet {
+	// Ignore addresses when running on the simulation and regression test
+	// networks.  This helps prevent the networks from becoming another public
+	// test network since they will not be able to learn about other peers that
+	// have not specifically been provided.
+	if cfg.SimNet || cfg.RegNet {
 		return
 	}
 
@@ -3360,13 +3360,13 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string, db database
 	mining.CoinbaseFlags = cfg.CoinbaseFlags
 
 	// Only setup a function to return new addresses to connect to when
-	// not running in connect-only mode.  The simulation network is always
-	// in connect-only mode since it is only intended to connect to
-	// specified peers and actively avoid advertising and connecting to
+	// not running in connect-only mode.  The simulation and regression networks
+	// are always in connect-only mode since they are only intended to connect
+	// to specified peers and actively avoid advertising and connecting to
 	// discovered peers in order to prevent it from becoming a public test
 	// network.
 	var newAddressFunc func() (net.Addr, error)
-	if !cfg.SimNet && len(cfg.ConnectPeers) == 0 {
+	if !cfg.SimNet && !cfg.RegNet && len(cfg.ConnectPeers) == 0 {
 		newAddressFunc = func() (net.Addr, error) {
 			for tries := 0; tries < 100; tries++ {
 				addr := s.addrManager.GetAddress()


### PR DESCRIPTION
This is a port of https://github.com/decred/dcrd/commit/f5fdd95eb578a485b414331836f9731fcd0f2756 to bchd.

This modifies the various aspects that deal with making nodes discoverable and making outbound connections to disable them when running in regression network test mode in the same way it is done for the simulation network test mode.