### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/blockchain/abla_ewma_elastic_buffer.go
+++ b/blockchain/abla_ewma_elastic_buffer.go
@@ -58,22 +58,6 @@ func muldiv(x, y, z uint64) uint64 {
 	return q.Lo
 }
 
-// Utility function
-func minUint64(a, b uint64) uint64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// Utility function
-func maxUint64(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // Algorithm configuration
 type ABLAConfig struct {
 	// Initial control block size value, also used as floor value
@@ -191,7 +175,7 @@ func (state *ABLAState) IsValid(config *ABLAConfig) (errs *strings.Builder) {
 // Calculate the limit for the block to which the algorithm's state
 // applies, given algorithm state
 func (state *ABLAState) getBlockSizeLimit() uint64 {
-	return minUint64(state.controlBlockSize+state.elasticBufferSize, TEMP_32_BIT_MAX_SAFE_BLOCKSIZE_LIMIT)
+	return min(state.controlBlockSize+state.elasticBufferSize, TEMP_32_BIT_MAX_SAFE_BLOCKSIZE_LIMIT)
 	// Note: Remove the TEMP_32_BIT_MAX_SAFE_BLOCKSIZE_LIMIT limit once 32-bit architecture is deprecated:
 	// return state.controlBlockSize + state.elasticBufferSize
 }
@@ -220,7 +204,7 @@ func (state *ABLAState) nextABLAState(config *ABLAConfig, currentBlockSize uint6
 	// For safety: we clamp this current block's blocksize to the maximum value this algorithm expects. Normally this
 	// won't happen unless the node is run with some -excessiveblocksize parameter that permits larger blocks than this
 	// algo's current state expects.
-	currentBlockSize = minUint64(currentBlockSize, state.controlBlockSize+state.elasticBufferSize)
+	currentBlockSize = min(currentBlockSize, state.controlBlockSize+state.elasticBufferSize)
 
 	// if block height is in range 0 to n0 inclusive use initialization values
 	// else use algorithmic limit
@@ -262,7 +246,7 @@ func (state *ABLAState) nextABLAState(config *ABLAConfig, currentBlockSize uint6
 			newState.controlBlockSize = state.controlBlockSize - bytesToRemove/config.gammaReciprocal
 
 			// epsilon_n = max(epsilon_{n-1} + gamma * (zeta * x_{n-1} - epsilon_{n-1}), epsilon_0)
-			newState.controlBlockSize = maxUint64(newState.controlBlockSize, config.epsilon0)
+			newState.controlBlockSize = max(newState.controlBlockSize, config.epsilon0)
 		}
 
 		// elastic buffer function
@@ -284,12 +268,12 @@ func (state *ABLAState) nextABLAState(config *ABLAConfig, currentBlockSize uint6
 		}
 		// max(beta_{n-1} - beta_{n-1} * theta + (epsilon_{n} - epsilon_{n-1}) * delta, beta_0) , if zeta * x_{n-1} > epsilon_{n-1}
 		// max(beta_{n-1} - beta_{n-1} * theta, beta_0) , if zeta * x_{n-1} <= epsilon_{n-1}
-		newState.elasticBufferSize = maxUint64(newState.elasticBufferSize, config.beta0)
+		newState.elasticBufferSize = max(newState.elasticBufferSize, config.beta0)
 
 		// clip controlBlockSize to epsilonMax to avoid integer overflow for extreme sizes
-		newState.controlBlockSize = minUint64(newState.controlBlockSize, config.epsilonMax)
+		newState.controlBlockSize = min(newState.controlBlockSize, config.epsilonMax)
 		// clip elasticBufferSize to betaMax to avoid integer overflow for extreme sizes
-		newState.elasticBufferSize = minUint64(newState.elasticBufferSize, config.betaMax)
+		newState.elasticBufferSize = min(newState.elasticBufferSize, config.betaMax)
 	}
 	return newState
 }

--- a/config.go
+++ b/config.go
@@ -91,24 +91,6 @@ var (
 // to parse and execute service commands specified via the -s flag.
 var runServiceCommand func(string) error
 
-// minUint32 is a helper function to return the minimum of two uint32s.
-// This avoids a math import and the need to cast to floats.
-func minUint32(a, b uint32) uint32 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// maxUint32 is a helper function to return the maximum of two uint32s.
-// This avoids a math import and the need to cast to floats.
-func maxUint32(a, b uint32) uint32 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // config defines the configuration options for bchd.
 //
 // See loadConfig for details on the configuration load process.
@@ -900,7 +882,7 @@ func loadConfig() (*config, []string, error) {
 	}
 
 	// Excessive blocksize cannot be set less than the default but it can be higher.
-	cfg.ExcessiveBlockSize = maxUint32(cfg.ExcessiveBlockSize, defaultExcessiveBlockSize)
+	cfg.ExcessiveBlockSize = max(cfg.ExcessiveBlockSize, defaultExcessiveBlockSize)
 
 	// Limit the max block size to a sane value.
 	blockMaxSizeMax := cfg.ExcessiveBlockSize - 1000
@@ -916,8 +898,8 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 	// Limit the block priority and minimum block sizes to max block size.
-	cfg.BlockPrioritySize = minUint32(cfg.BlockPrioritySize, cfg.BlockMaxSize)
-	cfg.BlockMinSize = minUint32(cfg.BlockMinSize, cfg.BlockMaxSize)
+	cfg.BlockPrioritySize = min(cfg.BlockPrioritySize, cfg.BlockMaxSize)
+	cfg.BlockMinSize = min(cfg.BlockMinSize, cfg.BlockMaxSize)
 
 	// Prepend ExcessiveBlockSize signaling to the UserAgentComments
 	cfg.UserAgentComments = append([]string{fmt.Sprintf("EB%.1f", float64(cfg.ExcessiveBlockSize)/1000000)}, cfg.UserAgentComments...)

--- a/mining/policy.go
+++ b/mining/policy.go
@@ -39,15 +39,6 @@ type Policy struct {
 	TxMinFreeFee bchutil.Amount
 }
 
-// minInt is a helper function to return the minimum of two ints.  This avoids
-// a math import and the need to cast to floats.
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // calcInputValueAge is a helper function used to calculate the input age of
 // a transaction.  The input age for a txin is the number of confirmations
 // since the referenced txout multiplied by its output value.  The total input
@@ -110,7 +101,7 @@ func CalcPriority(tx *wire.MsgTx, utxoView *blockchain.UtxoViewpoint, nextBlockH
 	overhead := 0
 	for _, txIn := range tx.TxIn {
 		// Max inputs + size can't possibly overflow here.
-		overhead += 41 + minInt(110, len(txIn.SignatureScript))
+		overhead += 41 + min(110, len(txIn.SignatureScript))
 	}
 
 	serializedTxSize := tx.SerializeSize()

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -306,15 +306,6 @@ type Config struct {
 	MaxKnownInventory uint
 }
 
-// minUint32 is a helper function to return the minimum of two uint32s.
-// This avoids a math import and the need to cast to floats.
-func minUint32(a, b uint32) uint32 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // newNetAddress attempts to extract the IP address and port from the passed
 // net.Addr interface and create a bitcoin NetAddress structure using that
 // information.
@@ -2117,7 +2108,7 @@ func (p *Peer) readRemoteVersionMsg() error {
 	// peer advertised.
 	p.flagsMtx.Lock()
 	p.advertisedProtoVer = uint32(msg.ProtocolVersion)
-	p.protocolVersion = minUint32(p.protocolVersion, p.advertisedProtoVer)
+	p.protocolVersion = min(p.protocolVersion, p.advertisedProtoVer)
 	p.versionKnown = true
 	p.services = msg.Services
 	p.flagsMtx.Unlock()


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max