### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -559,10 +559,7 @@ func (b *BlockChain) calcSequenceLock(node *blockNode, tx *bchutil.Tx, utxoView 
 			// which this input was included within so we can
 			// compute the past median time for the block prior to
 			// the one which included this referenced output.
-			prevInputHeight := inputHeight - 1
-			if prevInputHeight < 0 {
-				prevInputHeight = 0
-			}
+			prevInputHeight := max(inputHeight-1, 0)
 			blockNode := node.Ancestor(prevInputHeight)
 			medianTime := blockNode.CalcPastMedianTime()
 

--- a/blockchain/chainview.go
+++ b/blockchain/chainview.go
@@ -388,10 +388,7 @@ func (c *chainView) blockLocator(node *blockNode) BlockLocator {
 
 		// Calculate height of previous node to include ensuring the
 		// final node is the genesis block.
-		height := node.height - step
-		if height < 0 {
-			height = 0
-		}
+		height := max(node.height-step, 0)
 
 		// When the node is in the current chain view, all of its
 		// ancestors must be too, so use a much faster O(1) lookup in

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -220,10 +220,7 @@ func TestFullBlocks(t *testing.T) {
 	// provided test instance and ensures that it failed to decode with a
 	// message error.
 	testRejectedNonCanonicalBlock := func(item fullblocktests.RejectedNonCanonicalBlock) {
-		headerLen := len(item.RawBlock)
-		if headerLen > 80 {
-			headerLen = 80
-		}
+		headerLen := min(len(item.RawBlock), 80)
 		blockHash := chainhash.DoubleHashH(item.RawBlock[0:headerLen])
 		blockHeight := item.Height
 		t.Logf("Testing block %s (hash %s, height %d)", item.Name,

--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -287,10 +287,7 @@ func dbFetchAddrIndexEntries(bucket internalBucket, addrKey [addrKeySize]byte, n
 
 	// Limit the number to load based on the number of available entries,
 	// the number to skip, and the number requested.
-	numToLoad := numEntries - numToSkip
-	if numToLoad > numRequested {
-		numToLoad = numRequested
-	}
+	numToLoad := min(numEntries-numToSkip, numRequested)
 
 	// Start the offset after all skipped entries and load the calculated
 	// number.


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.