### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -666,10 +666,7 @@ func (a *AddrManager) NeedMoreAddresses() bool {
 func (a *AddrManager) AddressCache() []*wire.NetAddress {
 	allAddr := a.getAddresses()
 
-	numAddresses := len(allAddr) * getAddrPercent / 100
-	if numAddresses > getAddrMax {
-		numAddresses = getAddrMax
-	}
+	numAddresses := min(len(allAddr)*getAddrPercent/100, getAddrMax)
 
 	// Fisher-Yates shuffle the array. We only need to do the first
 	// `numAddresses' since we are throwing the rest.

--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -43,11 +43,7 @@ func (ka *KnownAddress) Services() wire.ServiceFlag {
 // attempted and how often attempts to connect to it have failed.
 func (ka *KnownAddress) chance() float64 {
 	now := time.Now()
-	lastAttempt := now.Sub(ka.lastattempt)
-
-	if lastAttempt < 0 {
-		lastAttempt = 0
-	}
+	lastAttempt := max(now.Sub(ka.lastattempt), 0)
 
 	c := 1.0
 

--- a/bchec/bchec.go
+++ b/bchec/bchec.go
@@ -803,10 +803,7 @@ func (curve *KoblitzCurve) scalarMultJacobian(Bx, By *big.Int, k []byte) (*field
 	k1Len := len(k1PosNAF)
 	k2Len := len(k2PosNAF)
 
-	m := k1Len
-	if m < k2Len {
-		m = k2Len
-	}
+	m := max(k1Len, k2Len)
 
 	// Add left-to-right using the NAF optimization.  See algorithm 3.77
 	// from [GECC].  This should be faster overall since there will be a lot

--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -2770,10 +2770,7 @@ func (s *GrpcServer) fetchTransactionsByAddress(addr bchutil.Address, startHeigh
 	// Override the default number of entries to skip if needed.
 	var numToSkip int
 	if nbSkip > 0 {
-		numToSkip = nbSkip
-		if numToSkip < 0 {
-			numToSkip = 0
-		}
+		numToSkip = max(nbSkip, 0)
 	}
 
 	// Add transactions from mempool first if client asked for reverse


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.