### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -203,10 +203,7 @@ func (cm *ConnManager) handleFailedConn(c *ConnReq) {
 	}
 	if c.Permanent {
 		c.retryCount++
-		d := time.Duration(c.retryCount) * cm.cfg.RetryDuration
-		if d > maxRetryDuration {
-			d = maxRetryDuration
-		}
+		d := min(time.Duration(c.retryCount)*cm.cfg.RetryDuration, maxRetryDuration)
 		log.Debugf("Retrying connection to %v in %v", c, d)
 		time.AfterFunc(d, func() {
 			cm.Connect(c)

--- a/limits/limits_unix.go
+++ b/limits/limits_unix.go
@@ -34,11 +34,7 @@ func SetLimits() error {
 			fileLimitMin)
 		return err
 	}
-	if rLimit.Max < fileLimitWant {
-		rLimit.Cur = rLimit.Max
-	} else {
-		rLimit.Cur = fileLimitWant
-	}
+	rLimit.Cur = min(rLimit.Max, fileLimitWant)
 	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
 		// try min value

--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -493,10 +493,7 @@ func (b *estimateFeeSet) estimateFee(confirmations int) SatoshiPerByte {
 		minVal += int(b.bin[i])
 	}
 
-	maxVal := minVal + int(b.bin[confirmations-1]) - 1
-	if maxVal < minVal {
-		maxVal = minVal
-	}
+	maxVal := max(minVal+int(b.bin[confirmations-1])-1, minVal)
 	feeIndex := (minVal + maxVal) / 2
 	if feeIndex >= len(b.feeRate) {
 		feeIndex = len(b.feeRate) - 1

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -579,10 +579,7 @@ func (sm *SyncManager) medianSyncPeerCandidateBlockHeight() int32 {
 			continue
 		}
 
-		topBlock := peer.LastBlock()
-		if topBlock < peer.StartingHeight() {
-			topBlock = peer.StartingHeight()
-		}
+		topBlock := max(peer.LastBlock(), peer.StartingHeight())
 
 		if topBlock < sm.topBlock() {
 			continue

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -652,10 +652,7 @@ out:
 				// retries so there is a backoff up to a max
 				// of 1 minute.
 				scaledInterval := connectionRetryInterval.Nanoseconds() * c.retryCount
-				scaledDuration := time.Duration(scaledInterval)
-				if scaledDuration > time.Minute {
-					scaledDuration = time.Minute
-				}
+				scaledDuration := min(time.Duration(scaledInterval), time.Minute)
 				log.Infof("Retrying connection to %s in "+
 					"%s", c.config.Host, scaledDuration)
 				time.Sleep(scaledDuration)
@@ -1389,10 +1386,7 @@ func (c *Client) Connect(tries int) error {
 		var wsConn *websocket.Conn
 		wsConn, err = dial(c.config)
 		if err != nil {
-			backoff = connectionRetryInterval * time.Duration(i+1)
-			if backoff > time.Minute {
-				backoff = time.Minute
-			}
+			backoff = min(connectionRetryInterval*time.Duration(i+1), time.Minute)
 			time.Sleep(backoff)
 			continue
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3403,10 +3403,7 @@ func fetchMempoolTxnsForAddress(s *rpcServer, addr bchutil.Address, numToSkip, n
 
 	// Filter the available entries based on the number to skip and number
 	// requested.
-	rangeEnd := numToSkip + numRequested
-	if rangeEnd > numAvailable {
-		rangeEnd = numAvailable
-	}
+	rangeEnd := min(numToSkip+numRequested, numAvailable)
 	return mpTxns[numToSkip:rangeEnd], numToSkip
 }
 
@@ -3467,10 +3464,7 @@ func handleSearchRawTransactions(s *rpcServer, cmd interface{}, closeNotifier <-
 	// Override the default number of entries to skip if needed.
 	var numToSkip int
 	if c.Skip != nil {
-		numToSkip = *c.Skip
-		if numToSkip < 0 {
-			numToSkip = 0
-		}
+		numToSkip = max(*c.Skip, 0)
 	}
 
 	// Override the reverse flag if needed.
@@ -3878,10 +3872,7 @@ func handleValidateAddress(s *rpcServer, cmd interface{}, closeNotifier <-chan b
 
 func verifyChain(s *rpcServer, level, depth int32) error {
 	best := s.cfg.Chain.BestSnapshot()
-	finishHeight := best.Height - depth
-	if finishHeight < 0 {
-		finishHeight = 0
-	}
+	finishHeight := max(best.Height-depth, 0)
 	rpcsLog.Infof("Verifying chain for %d blocks at level %d",
 		best.Height-finishHeight, level)
 

--- a/wire/common_test.go
+++ b/wire/common_test.go
@@ -52,10 +52,7 @@ func init() {
 // Read returns the fake reader error and the lesser of the fake reader value
 // and the length of p.
 func (r *fakeRandReader) Read(p []byte) (int, error) {
-	n := r.n
-	if n > len(p) {
-		n = len(p)
-	}
+	n := min(r.n, len(p))
 	return n, r.err
 }
 


### PR DESCRIPTION

Inspired by https://github.com/gcash/bchd/pull/571

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.