### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/blockchain/checkpoints.go
+++ b/blockchain/checkpoints.go
@@ -6,6 +6,7 @@ package blockchain
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/gcash/bchd/chaincfg"
@@ -250,10 +251,8 @@ func (b *BlockChain) IsCheckpointCandidate(block *bchutil.Block) (bool, error) {
 
 	// A checkpoint must have transactions that only contain standard
 	// scripts.
-	for _, tx := range block.Transactions() {
-		if isNonstandardTransaction(tx) {
-			return false, nil
-		}
+	if slices.ContainsFunc(block.Transactions(), isNonstandardTransaction) {
+		return false, nil
 	}
 
 	// All of the checks passed, so the block is a candidate.

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -51,13 +52,7 @@ func fileExists(name string) bool {
 // currently supported.
 func isSupportedDbType(dbType string) bool {
 	supportedDrivers := database.SupportedDrivers()
-	for _, driver := range supportedDrivers {
-		if dbType == driver {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(supportedDrivers, dbType)
 }
 
 // loadBlocks reads files containing bitcoin block data (gzipped but otherwise

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/gcash/bchd/blockchain"
@@ -48,13 +49,7 @@ func fileExists(name string) bool {
 // currently supported.
 func isSupportedDbType(dbType string) bool {
 	supportedDrivers := database.SupportedDrivers()
-	for _, driver := range supportedDrivers {
-		if dbType == driver {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(supportedDrivers, dbType)
 }
 
 // chainSetup is used to create a new db and chain instance with the genesis


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.