### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/integration/rpctest/memwallet.go
+++ b/integration/rpctest/memwallet.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/gcash/bchd/bchec"
@@ -324,9 +325,7 @@ func (m *memWallet) unwindBlock(update *chainUpdate) {
 		delete(m.utxos, utxo)
 	}
 
-	for outPoint, utxo := range undo.utxosDestroyed {
-		m.utxos[outPoint] = utxo
-	}
+	maps.Copy(m.utxos, undo.utxosDestroyed)
 
 	delete(m.reorgJournal, update.blockHeight)
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.