### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/bchec/genprecomps.go
+++ b/bchec/genprecomps.go
@@ -6,7 +6,6 @@
 // It is called by go generate and used to automatically generate pre-computed
 // tables used to accelerate operations.
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/bchec/gensecp256k1.go
+++ b/bchec/gensecp256k1.go
@@ -5,7 +5,6 @@
 // This file is ignored during the regular build due to the following build tag.
 // This build tag is set during go generate.
 //go:build gensecp256k1
-// +build gensecp256k1
 
 package bchec
 

--- a/bchrpc/proxy/gw_tools.go
+++ b/bchrpc/proxy/gw_tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package main
 

--- a/database/ffldb/disk.go
+++ b/database/ffldb/disk.go
@@ -1,5 +1,4 @@
 //go:build solaris || plan9 || netbsd || openbsd
-// +build solaris plan9 netbsd openbsd
 
 // Copyright (c) 2013-2018 The btcsuite developers
 // Use of this source code is governed by an ISC

--- a/database/ffldb/disk_darwin.go
+++ b/database/ffldb/disk_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 // Copyright (c) 2013-2018 The btcsuite developers
 // Use of this source code is governed by an ISC

--- a/database/ffldb/disk_dragonfly.go
+++ b/database/ffldb/disk_dragonfly.go
@@ -1,5 +1,4 @@
 //go:build dragonfly
-// +build dragonfly
 
 // Copyright (c) 2013-2018 The btcsuite developers
 // Use of this source code is governed by an ISC

--- a/database/ffldb/disk_freebsd.go
+++ b/database/ffldb/disk_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 // Copyright (c) 2013-2018 The btcsuite developers
 // Use of this source code is governed by an ISC

--- a/database/ffldb/disk_linux.go
+++ b/database/ffldb/disk_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2013-2018 The btcsuite developers
 // Use of this source code is governed by an ISC

--- a/database/ffldb/disk_windows.go
+++ b/database/ffldb/disk_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright (c) 2013-2018 The btcsuite developers
 // Use of this source code is governed by an ISC

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -4,7 +4,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package integration
 
@@ -282,19 +281,20 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 // - Assert the chain height is 0 and the state is ThresholdDefined
 // - Generate 1 fewer blocks than needed to reach the first state transition
 //   - Assert chain height is expected and state is still ThresholdDefined
+//
 // - Generate 1 more block to reach the first state transition
 //   - Assert chain height is expected and state moved to ThresholdStarted
-// - Generate enough blocks to reach the next state transition window, but only
-//   signal support in 1 fewer than the required number to achieve
-//   ThresholdLockedIn
+//   - Generate enough blocks to reach the next state transition window, but only
+//     signal support in 1 fewer than the required number to achieve
+//     ThresholdLockedIn
 //   - Assert chain height is expected and state is still ThresholdStarted
-// - Generate enough blocks to reach the next state transition window with only
-//   the exact number of blocks required to achieve locked in status signalling
-//   support.
+//   - Generate enough blocks to reach the next state transition window with only
+//     the exact number of blocks required to achieve locked in status signalling
+//     support.
 //   - Assert chain height is expected and state moved to ThresholdLockedIn
-// - Generate 1 fewer blocks than needed to reach the next state transition
+//   - Generate 1 fewer blocks than needed to reach the next state transition
 //   - Assert chain height is expected and state is still ThresholdLockedIn
-// - Generate 1 more block to reach the next state transition
+//   - Generate 1 more block to reach the next state transition
 //   - Assert chain height is expected and state moved to ThresholdActive
 func TestBIP0009(t *testing.T) {
 	t.Parallel()
@@ -308,11 +308,14 @@ func TestBIP0009(t *testing.T) {
 // Overview:
 // - Generate block 1
 //   - Assert bit is NOT set (ThresholdDefined)
+//
 // - Generate enough blocks to reach first state transition
 //   - Assert bit is NOT set for block prior to state transition
 //   - Assert bit is set for block at state transition (ThresholdStarted)
+//
 // - Generate enough blocks to reach second state transition
 //   - Assert bit is set for block at state transition (ThresholdLockedIn)
+//
 // - Generate enough blocks to reach third state transition
 //   - Assert bit is set for block prior to state transition (ThresholdLockedIn)
 //   - Assert bit is NOT set for block at state transition (ThresholdActive)

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -4,7 +4,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package integration
 
@@ -102,17 +101,22 @@ func makeTestOutput(r *rpctest.Harness, t *testing.T,
 // them.
 //
 // Overview:
-//  - Pre soft-fork:
-//    - Transactions with non-final lock-times from the PoV of MTP should be
-//      rejected from the mempool.
-//    - Transactions within non-final MTP based lock-times should be accepted
-//      in valid blocks.
 //
-//  - Post soft-fork:
-//    - Transactions with non-final lock-times from the PoV of MTP should be
-//      rejected from the mempool and when found within otherwise valid blocks.
-//    - Transactions with final lock-times from the PoV of MTP should be
-//      accepted to the mempool and mined in future block.
+//   - Pre soft-fork:
+//
+//   - Transactions with non-final lock-times from the PoV of MTP should be
+//     rejected from the mempool.
+//
+//   - Transactions within non-final MTP based lock-times should be accepted
+//     in valid blocks.
+//
+//   - Post soft-fork:
+//
+//   - Transactions with non-final lock-times from the PoV of MTP should be
+//     rejected from the mempool and when found within otherwise valid blocks.
+//
+//   - Transactions with final lock-times from the PoV of MTP should be
+//     accepted to the mempool and mined in future block.
 func TestBIP0113Activation(t *testing.T) {
 	t.Parallel()
 
@@ -414,13 +418,13 @@ func assertTxInBlock(r *rpctest.Harness, t *testing.T, blockHash *chainhash.Hash
 // 112 and BIP 68 rule-set after the activation of the CSV-package soft-fork.
 //
 // Overview:
-//  - Pre soft-fork:
-//    - A transaction spending a CSV output validly should be rejected from the
-//    mempool, but accepted in a valid generated block including the
-//    transaction.
-//  - Post soft-fork:
-//    - See the cases exercised within the table driven tests towards the end
-//    of this test.
+//   - Pre soft-fork:
+//   - A transaction spending a CSV output validly should be rejected from the
+//     mempool, but accepted in a valid generated block including the
+//     transaction.
+//   - Post soft-fork:
+//   - See the cases exercised within the table driven tests towards the end
+//     of this test.
 func TestBIP0068AndBIP0112Activation(t *testing.T) {
 	t.Parallel()
 

--- a/integration/rpcserver_test.go
+++ b/integration/rpcserver_test.go
@@ -4,7 +4,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package integration
 

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -4,7 +4,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package rpctest
 

--- a/limits/limits_unix.go
+++ b/limits/limits_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !plan9
-// +build !windows,!plan9
 
 package limits
 

--- a/signalsigterm.go
+++ b/signalsigterm.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main
 


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild


