### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/bchec/bchec.go
+++ b/bchec/bchec.go
@@ -22,6 +22,7 @@ package bchec
 import (
 	"crypto/elliptic"
 	"math/big"
+	"slices"
 	"sync"
 )
 
@@ -698,8 +699,7 @@ func NAF(k []byte) ([]byte, []byte) {
 	// these default to zero
 	retPos := make([]byte, len(k)+1)
 	retNeg := make([]byte, len(k)+1)
-	for i := len(k) - 1; i >= 0; i-- {
-		curByte := k[i]
+	for i, curByte := range slices.Backward(k) {
 		for j := uint(0); j < 8; j++ {
 			curIsOne = curByte&1 == 1
 			if j == 7 {

--- a/bchrpc/txfilter.go
+++ b/bchrpc/txfilter.go
@@ -3,6 +3,7 @@ package bchrpc
 import (
 	"encoding/hex"
 	"fmt"
+	"slices"
 
 	"github.com/gcash/bchd/bchrpc/pb"
 	"github.com/gcash/bchd/chaincfg"
@@ -251,8 +252,8 @@ func (f *txFilter) MatchAndUpdate(tx *bchutil.Tx, params *chaincfg.Params) bool 
 				case *v1parser.SlpGenesis:
 					txnHash := tx.Hash().CloneBytes()
 					var txid []byte
-					for i := len(txnHash) - 1; i >= 0; i-- {
-						txid = append(txid, txnHash[i])
+					for _, v := range slices.Backward(txnHash) {
+						txid = append(txid, v)
 					}
 					copy(tokenID[:], txid)
 				case *v1parser.SlpMint:

--- a/blockchain/indexers/slpindex.go
+++ b/blockchain/indexers/slpindex.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/big"
 	"runtime"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -380,8 +381,8 @@ func dbRemoveSlpIndexEntries(dbTx database.Tx, block *bchutil.Block) error {
 	// toposort and reverse order so we can unwind slp token metadata state if needed
 	txs := TopologicallySortTxs(block.Transactions())
 	var txsRev []*wire.MsgTx
-	for i := len(txs) - 1; i >= 0; i-- {
-		txsRev = append(txsRev, txs[i])
+	for _, v := range slices.Backward(txs) {
+		txsRev = append(txsRev, v)
 	}
 
 	// this method should only be called after a topological sort

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -6,6 +6,7 @@ package blockchain
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/gcash/bchd/chaincfg"
 	"github.com/gcash/bchd/chaincfg/chainhash"
@@ -186,8 +187,7 @@ func (b *BlockChain) thresholdState(prevNode *blockNode, checker thresholdCondit
 
 	// Since each threshold state depends on the state of the previous
 	// window, iterate starting from the oldest unknown window.
-	for neededNum := len(neededStates) - 1; neededNum >= 0; neededNum-- {
-		prevNode := neededStates[neededNum]
+	for _, prevNode := range slices.Backward(neededStates) {
 
 		switch state {
 		case ThresholdDefined:

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1280,8 +1280,8 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 	// not be one.
 	lastBlock := -1
 	invVects := imsg.inv.InvList
-	for i := len(invVects) - 1; i >= 0; i-- {
-		if invVects[i].Type == wire.InvTypeBlock {
+	for i, v := range slices.Backward(invVects) {
+		if v.Type == wire.InvTypeBlock {
 			lastBlock = i
 			break
 		}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899