### PR TITLE
chore: fix function name in comment to match actual function

### DIFF
--- a/connmgr/dynamicbanscore_test.go
+++ b/connmgr/dynamicbanscore_test.go
@@ -49,8 +49,7 @@ func TestDynamicBanScoreLifetime(t *testing.T) {
 	}
 }
 
-// TestDynamicBanScore tests exported functions of DynamicBanScore. Exponential
-// decay or other time based behavior is tested by other functions.
+// TestDynamicBanScoreReset tests the Reset method of DynamicBanScore.
 func TestDynamicBanScoreReset(t *testing.T) {
 	var bs DynamicBanScore
 	if bs.Int() != 0 {


### PR DESCRIPTION
fix function name in comment to match actual function