### PR TITLE
refactor: use WaitGroup.Go to simplify code

### DIFF
--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -204,11 +204,9 @@ func (s *GrpcServer) subscribeEvents() *rpcEventSubscription {
 
 	// Start a queue handler for the subscription so that slow connections don't
 	// hold up faster ones.
-	s.wg.Add(1)
-	go func() {
+	s.wg.Go(func() {
 		queueHandler(sub.in, sub.out, s.quit)
-		s.wg.Done()
-	}()
+	})
 
 	select {
 	case s.subscribe <- sub:


### PR DESCRIPTION
use WaitGroup.Go to simplify code. More info: https://github.com/golang/go/issues/63796