### PR TITLE
dnsseed.electroncash.de is no more

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -284,7 +284,6 @@ var MainNetParams = Params{
 		{"seed.bchd.cash", true},
 		{"btccash-seeder.bitcoinunlimited.info", true},
 		{"seed.bch.loping.net", true},
-		{"dnsseed.electroncash.de", true},
 	},
 
 	// Chain parameters


### PR DESCRIPTION
The electroncash.de domain has been defunct. Confirmed by Georg Engelmann.

<img width="250" height="144" alt="image" src="https://github.com/user-attachments/assets/a47843ca-797f-4893-8b25-20951f76fcb6" />

