### PR TITLE
refactor: modernize sync/atomic usage with typed atomic apis

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -38,8 +38,8 @@ type AddrManager struct {
 	addrIndex      map[string]*KnownAddress // address key to ka for all addrs.
 	addrNew        [newBucketCount]map[string]*KnownAddress
 	addrTried      [triedBucketCount]*list.List
-	started        int32
-	shutdown       int32
+	started        atomic.Int32
+	shutdown       atomic.Int32
 	wg             sync.WaitGroup
 	quit           chan struct{}
 	nTried         int
@@ -567,7 +567,7 @@ func (a *AddrManager) DeserializeNetAddress(addr string,
 // addresses, timeouts, and interval based writes.
 func (a *AddrManager) Start() {
 	// Already started?
-	if atomic.AddInt32(&a.started, 1) != 1 {
+	if a.started.Add(1) != 1 {
 		return
 	}
 
@@ -583,7 +583,7 @@ func (a *AddrManager) Start() {
 
 // Stop gracefully shuts down the address manager by stopping the main handler.
 func (a *AddrManager) Stop() error {
-	if atomic.AddInt32(&a.shutdown, 1) != 1 {
+	if a.shutdown.Add(1) != 1 {
 		log.Warnf("Address manager is already in the process of " +
 			"shutting down")
 		return nil

--- a/bchrpc/server.go
+++ b/bchrpc/server.go
@@ -125,8 +125,8 @@ type GrpcServer struct {
 	quit       chan struct{}
 
 	wg       sync.WaitGroup
-	ready    uint32 // atomic
-	shutdown int32  // atomic
+	ready    atomic.Uint32 // atomic
+	shutdown int32         // atomic
 }
 
 // NewGrpcServer returns a new GrpcServer which has not yet
@@ -292,7 +292,7 @@ func (s *GrpcServer) handleBlockchainNotification(notification *blockchain.Notif
 // Start will start the GrpcServer, subscribe to blockchain notifications
 // and start the EventDispatcher in a new goroutine.
 func (s *GrpcServer) Start() {
-	if atomic.SwapUint32(&s.ready, 1) != 0 {
+	if s.ready.Swap(1) != 0 {
 		panic("service already started")
 	}
 
@@ -321,7 +321,7 @@ func (s *GrpcServer) Stop() error {
 
 // checkReady returns if the server is ready to serve data.
 func (s *GrpcServer) checkReady() bool {
-	return atomic.LoadUint32(&s.ready) != 0
+	return s.ready.Load() != 0
 }
 
 // GetMempoolInfo returns the state of the current mempool.

--- a/blockchain/scriptval.go
+++ b/blockchain/scriptval.go
@@ -36,7 +36,7 @@ type txValidator struct {
 	flags              txscript.ScriptFlags
 	sigCache           *txscript.SigCache
 	hashCache          *txscript.HashCache
-	sigChecks          uint32
+	sigChecks          atomic.Uint32
 	maxSigChecks       uint32
 	upgrade9ForkHeight int32
 }
@@ -166,7 +166,7 @@ out:
 			}
 
 			if v.maxSigChecks > 0 && v.flags.HasFlag(txscript.ScriptReportSigChecks) {
-				if atomic.AddUint32(&v.sigChecks, uint32(vm.SigChecks())) > v.maxSigChecks {
+				if v.sigChecks.Add(uint32(vm.SigChecks())) > v.maxSigChecks {
 					str := "block too many sig checks"
 					err := ruleError(ErrTooManySigChecks, str)
 					v.sendResult(err)

--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -181,9 +181,9 @@ type checkDuplicate struct {
 // ConnManager provides a manager to handle network connections.
 type ConnManager struct {
 	// The following variables must only be used atomically.
-	connReqCount uint64
-	start        int32
-	stop         int32
+	connReqCount atomic.Uint64
+	start        atomic.Int32
+	stop         atomic.Int32
 
 	cfg            Config
 	wg             sync.WaitGroup
@@ -198,7 +198,7 @@ type ConnManager struct {
 // After maxFailedConnectionAttempts new connections will be retried after the
 // configured retry duration.
 func (cm *ConnManager) handleFailedConn(c *ConnReq) {
-	if atomic.LoadInt32(&cm.stop) != 0 {
+	if cm.stop.Load() != 0 {
 		return
 	}
 	if c.Permanent {
@@ -384,7 +384,7 @@ out:
 // NewConnReq creates a new connection request and connects to the
 // corresponding address.
 func (cm *ConnManager) NewConnReq() {
-	if atomic.LoadInt32(&cm.stop) != 0 {
+	if cm.stop.Load() != 0 {
 		return
 	}
 	if cm.cfg.GetNewAddress == nil {
@@ -392,7 +392,7 @@ func (cm *ConnManager) NewConnReq() {
 	}
 
 	c := &ConnReq{}
-	atomic.StoreUint64(&c.id, atomic.AddUint64(&cm.connReqCount, 1))
+	atomic.StoreUint64(&c.id, cm.connReqCount.Add(1))
 
 	// Submit a request of a pending connection attempt to the connection
 	// manager. By registering the id before the connection is even
@@ -445,7 +445,7 @@ func (cm *ConnManager) NewConnReq() {
 // Connect assigns an id and dials a connection to the address of the
 // connection request.
 func (cm *ConnManager) Connect(c *ConnReq) {
-	if atomic.LoadInt32(&cm.stop) != 0 {
+	if cm.stop.Load() != 0 {
 		return
 	}
 
@@ -457,7 +457,7 @@ func (cm *ConnManager) Connect(c *ConnReq) {
 	}
 
 	if atomic.LoadUint64(&c.id) == 0 {
-		atomic.StoreUint64(&c.id, atomic.AddUint64(&cm.connReqCount, 1))
+		atomic.StoreUint64(&c.id, cm.connReqCount.Add(1))
 
 		// Submit a request of a pending connection attempt to the
 		// connection manager. By registering the id before the
@@ -500,7 +500,7 @@ func (cm *ConnManager) Connect(c *ConnReq) {
 // id. If permanent, the connection will be retried with an increasing backoff
 // duration.
 func (cm *ConnManager) Disconnect(id uint64) {
-	if atomic.LoadInt32(&cm.stop) != 0 {
+	if cm.stop.Load() != 0 {
 		return
 	}
 
@@ -516,7 +516,7 @@ func (cm *ConnManager) Disconnect(id uint64) {
 // NOTE: This method can also be used to cancel a lingering connection attempt
 // that hasn't yet succeeded.
 func (cm *ConnManager) Remove(id uint64) {
-	if atomic.LoadInt32(&cm.stop) != 0 {
+	if cm.stop.Load() != 0 {
 		return
 	}
 
@@ -530,11 +530,11 @@ func (cm *ConnManager) Remove(id uint64) {
 // run as a goroutine.
 func (cm *ConnManager) listenHandler(listener net.Listener) {
 	log.Infof("Server listening on %s", listener.Addr())
-	for atomic.LoadInt32(&cm.stop) == 0 {
+	for cm.stop.Load() == 0 {
 		conn, err := listener.Accept()
 		if err != nil {
 			// Only log the error if not forcibly shutting down.
-			if atomic.LoadInt32(&cm.stop) == 0 {
+			if cm.stop.Load() == 0 {
 				log.Errorf("Can't accept connection: %v", err)
 			}
 			continue
@@ -549,7 +549,7 @@ func (cm *ConnManager) listenHandler(listener net.Listener) {
 // Start launches the connection manager and begins connecting to the network.
 func (cm *ConnManager) Start() {
 	// Already started?
-	if atomic.AddInt32(&cm.start, 1) != 1 {
+	if cm.start.Add(1) != 1 {
 		return
 	}
 
@@ -566,7 +566,7 @@ func (cm *ConnManager) Start() {
 		}
 	}
 
-	for i := atomic.LoadUint64(&cm.connReqCount); i < uint64(cm.cfg.TargetOutbound); i++ {
+	for i := cm.connReqCount.Load(); i < uint64(cm.cfg.TargetOutbound); i++ {
 		go cm.NewConnReq()
 	}
 }
@@ -578,7 +578,7 @@ func (cm *ConnManager) Wait() {
 
 // Stop gracefully shuts down the connection manager.
 func (cm *ConnManager) Stop() {
-	if atomic.AddInt32(&cm.stop, 1) != 1 {
+	if cm.stop.Add(1) != 1 {
 		log.Warnf("Connection manager already stopped")
 		return
 	}

--- a/connmgr/connmanager_test.go
+++ b/connmgr/connmanager_test.go
@@ -354,9 +354,9 @@ func TestMaxRetryDuration(t *testing.T) {
 // TestNetworkFailure tests that the connection manager handles a network
 // failure gracefully.
 func TestNetworkFailure(t *testing.T) {
-	var dials uint32
+	var dials atomic.Uint32
 	errDialer := func(_ net.Addr) (net.Conn, error) {
-		atomic.AddUint32(&dials, 1)
+		dials.Add(1)
 		return nil, errors.New("network down")
 	}
 	cmgr, err := New(&Config{
@@ -380,9 +380,9 @@ func TestNetworkFailure(t *testing.T) {
 	time.AfterFunc(10*time.Millisecond, cmgr.Stop)
 	cmgr.Wait()
 	wantMaxDials := uint32(75)
-	if atomic.LoadUint32(&dials) > wantMaxDials {
+	if dials.Load() > wantMaxDials {
 		t.Fatalf("network failure: unexpected number of dials - got %v, want < %v",
-			atomic.LoadUint32(&dials), wantMaxDials)
+			dials.Load(), wantMaxDials)
 	}
 }
 
@@ -408,9 +408,9 @@ func TestStopFailed(t *testing.T) {
 	cmgr.Start()
 	go func() {
 		<-done
-		atomic.StoreInt32(&cmgr.stop, 1)
+		cmgr.stop.Store(1)
 		time.Sleep(2 * time.Millisecond)
-		atomic.StoreInt32(&cmgr.stop, 0)
+		cmgr.stop.Store(0)
 		cmgr.Stop()
 	}()
 	cr := &ConnReq{

--- a/database/ffldb/interface_test.go
+++ b/database/ffldb/interface_test.go
@@ -2191,17 +2191,17 @@ func testConcurrentClose(tc *testContext) bool {
 	// Start up a few readers and wait for them to acquire views.  Each
 	// reader waits for a signal to complete to ensure the transactions stay
 	// open until they are explicitly signalled to be closed.
-	var activeReaders int32
+	var activeReaders atomic.Int32
 	numReaders := 3
 	started := make(chan struct{})
 	finishReaders := make(chan struct{})
 	resultChan := make(chan bool, numReaders+1)
 	reader := func() {
 		err := tc.db.View(func(_ database.Tx) error {
-			atomic.AddInt32(&activeReaders, 1)
+			activeReaders.Add(1)
 			started <- struct{}{}
 			<-finishReaders
-			atomic.AddInt32(&activeReaders, -1)
+			activeReaders.Add(-1)
 			return nil
 		})
 		if err != nil {
@@ -2240,7 +2240,7 @@ func testConcurrentClose(tc *testContext) bool {
 	// active readers open.
 	time.AfterFunc(time.Millisecond*250, func() { close(finishReaders) })
 	<-dbClosed
-	if nr := atomic.LoadInt32(&activeReaders); nr != 0 {
+	if nr := activeReaders.Load(); nr != 0 {
 		tc.t.Errorf("Close did not appear to block with active "+
 			"readers: %d active", nr)
 		return false

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -164,7 +164,7 @@ type orphanTx struct {
 // peers.
 type TxPool struct {
 	// The following variables must only be used atomically.
-	lastUpdated int64 // last time pool was updated
+	lastUpdated atomic.Int64 // last time pool was updated
 
 	mtx           sync.RWMutex
 	cfg           Config
@@ -481,7 +481,7 @@ func (mp *TxPool) removeTransaction(tx *bchutil.Tx, removeRedeemers bool) {
 			delete(mp.outpoints, txIn.PreviousOutPoint)
 		}
 		delete(mp.pool, *txHash)
-		atomic.StoreInt64(&mp.lastUpdated, time.Now().Unix())
+		mp.lastUpdated.Store(time.Now().Unix())
 	}
 }
 
@@ -541,7 +541,7 @@ func (mp *TxPool) addTransaction(utxoView *blockchain.UtxoViewpoint, tx *bchutil
 	for _, txIn := range tx.MsgTx().TxIn {
 		mp.outpoints[txIn.PreviousOutPoint] = tx
 	}
-	atomic.StoreInt64(&mp.lastUpdated, time.Now().Unix())
+	mp.lastUpdated.Store(time.Now().Unix())
 
 	// Add unconfirmed address index entries associated with the transaction
 	// if enabled.
@@ -1303,7 +1303,7 @@ func (mp *TxPool) RawMempoolVerbose() map[string]*btcjson.GetRawMempoolVerboseRe
 //
 // This function is safe for concurrent access.
 func (mp *TxPool) LastUpdated() time.Time {
-	return time.Unix(atomic.LoadInt64(&mp.lastUpdated), 0)
+	return time.Unix(mp.lastUpdated.Load(), 0)
 }
 
 // DecodeCompressedBlock takes in a block interface and attempts to decode it

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -216,8 +216,8 @@ func (sps *syncPeerState) updateNetwork(syncPeer *peerpkg.Peer) {
 // notifications and relays announcements of new blocks to peers.
 type SyncManager struct {
 	peerNotifier   PeerNotifier
-	started        int32
-	shutdown       int32
+	started        atomic.Int32
+	shutdown       atomic.Int32
 	chain          *blockchain.BlockChain
 	txMemPool      *mempool.TxPool
 	chainParams    *chaincfg.Params
@@ -487,7 +487,7 @@ func (sm *SyncManager) handleNewPeerMsg(peer *peerpkg.Peer) {
 	}
 
 	// Ignore if in the process of shutting down.
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		return
 	}
 
@@ -519,7 +519,7 @@ func (sm *SyncManager) handleNewPeerMsg(peer *peerpkg.Peer) {
 
 // handleCheckSyncPeer selects a new sync peer.
 func (sm *SyncManager) handleCheckSyncPeer() {
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		return
 	}
 
@@ -658,7 +658,7 @@ func (sm *SyncManager) clearRequestedState(state *peerSyncState) {
 // updateSyncPeer picks a new peer to sync from.
 func (sm *SyncManager) updateSyncPeer() {
 	// Ignore if we are shutting down.
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		return
 	}
 
@@ -1669,7 +1669,7 @@ func (sm *SyncManager) NewPeer(peer *peerpkg.Peer, done chan struct{}) {
 	}
 
 	// Ignore if we are shutting down.
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		done <- struct{}{}
 		return
 	}
@@ -1681,7 +1681,7 @@ func (sm *SyncManager) NewPeer(peer *peerpkg.Peer, done chan struct{}) {
 // processed.
 func (sm *SyncManager) QueueTx(tx *bchutil.Tx, peer *peerpkg.Peer, done chan struct{}) {
 	// Don't accept more transactions if we're shutting down.
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		done <- struct{}{}
 		return
 	}
@@ -1694,7 +1694,7 @@ func (sm *SyncManager) QueueTx(tx *bchutil.Tx, peer *peerpkg.Peer, done chan str
 // processed.
 func (sm *SyncManager) QueueBlock(block *bchutil.Block, peer *peerpkg.Peer, done chan struct{}) {
 	// Don't accept more blocks if we're shutting down.
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		done <- struct{}{}
 		return
 	}
@@ -1705,7 +1705,7 @@ func (sm *SyncManager) QueueBlock(block *bchutil.Block, peer *peerpkg.Peer, done
 // QueueBlockError adds the passed block message and peer to the block handling
 // queue to remove the requested block for our queues.
 func (sm *SyncManager) QueueBlockError(hash *chainhash.Hash, peer *peerpkg.Peer) {
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		return
 	}
 	sm.msgChan <- &blockErrorMsg{hash: hash, peer: peer}
@@ -1715,7 +1715,7 @@ func (sm *SyncManager) QueueBlockError(hash *chainhash.Hash, peer *peerpkg.Peer)
 func (sm *SyncManager) QueueInv(inv *wire.MsgInv, peer *peerpkg.Peer) {
 	// No channel handling here because peers do not need to block on inv
 	// messages.
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		return
 	}
 
@@ -1727,7 +1727,7 @@ func (sm *SyncManager) QueueInv(inv *wire.MsgInv, peer *peerpkg.Peer) {
 func (sm *SyncManager) QueueHeaders(headers *wire.MsgHeaders, peer *peerpkg.Peer) {
 	// No channel handling here because peers do not need to block on
 	// headers messages.
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		return
 	}
 
@@ -1737,7 +1737,7 @@ func (sm *SyncManager) QueueHeaders(headers *wire.MsgHeaders, peer *peerpkg.Peer
 // DonePeer informs the blockmanager that a peer has disconnected.
 func (sm *SyncManager) DonePeer(peer *peerpkg.Peer, done chan struct{}) {
 	// Ignore if we are shutting down.
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
+	if sm.shutdown.Load() != 0 {
 		done <- struct{}{}
 		return
 	}
@@ -1748,7 +1748,7 @@ func (sm *SyncManager) DonePeer(peer *peerpkg.Peer, done chan struct{}) {
 // Start begins the core block handler which processes block and inv messages.
 func (sm *SyncManager) Start() {
 	// Already started?
-	if atomic.AddInt32(&sm.started, 1) != 1 {
+	if sm.started.Add(1) != 1 {
 		return
 	}
 
@@ -1760,7 +1760,7 @@ func (sm *SyncManager) Start() {
 // Stop gracefully shuts down the sync manager by stopping all asynchronous
 // handlers and waiting for them to finish.
 func (sm *SyncManager) Stop() error {
-	if atomic.AddInt32(&sm.shutdown, 1) != 1 {
+	if sm.shutdown.Add(1) != 1 {
 		log.Warnf("Sync manager is already in the process of " +
 			"shutting down")
 		return nil

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -75,7 +75,7 @@ const (
 var (
 	// nodeCount is the total number of peer connections made since startup
 	// and is used to assign an id to a peer.
-	nodeCount int32
+	nodeCount atomic.Int32
 
 	// zeroHash is the zero value hash (all zeros).  It is defined as a
 	// convenience.
@@ -442,12 +442,12 @@ type HostToNetAddrFunc func(host string, port uint16,
 // provided as a convenience.
 type Peer struct {
 	// The following variables must only be used atomically.
-	bytesReceived uint64
-	bytesSent     uint64
-	lastRecv      int64
-	lastSend      int64
-	connected     int32
-	disconnect    int32
+	bytesReceived atomic.Uint64
+	bytesSent     atomic.Uint64
+	lastRecv      atomic.Int64
+	lastSend      atomic.Int64
+	connected     atomic.Int32
+	disconnect    atomic.Int32
 
 	conn net.Conn
 
@@ -799,14 +799,14 @@ func (p *Peer) LastBlock() int32 {
 //
 // This function is safe for concurrent access.
 func (p *Peer) LastSend() time.Time {
-	return time.Unix(atomic.LoadInt64(&p.lastSend), 0)
+	return time.Unix(p.lastSend.Load(), 0)
 }
 
 // LastRecv returns the last recv time of the peer.
 //
 // This function is safe for concurrent access.
 func (p *Peer) LastRecv() time.Time {
-	return time.Unix(atomic.LoadInt64(&p.lastRecv), 0)
+	return time.Unix(p.lastRecv.Load(), 0)
 }
 
 // LocalAddr returns the local address of the connection.
@@ -814,7 +814,7 @@ func (p *Peer) LastRecv() time.Time {
 // This function is safe fo concurrent access.
 func (p *Peer) LocalAddr() net.Addr {
 	var localAddr net.Addr
-	if atomic.LoadInt32(&p.connected) != 0 {
+	if p.connected.Load() != 0 {
 		localAddr = p.conn.LocalAddr()
 	}
 	return localAddr
@@ -824,14 +824,14 @@ func (p *Peer) LocalAddr() net.Addr {
 //
 // This function is safe for concurrent access.
 func (p *Peer) BytesSent() uint64 {
-	return atomic.LoadUint64(&p.bytesSent)
+	return p.bytesSent.Load()
 }
 
 // BytesReceived returns the total number of bytes received by the peer.
 //
 // This function is safe for concurrent access.
 func (p *Peer) BytesReceived() uint64 {
-	return atomic.LoadUint64(&p.bytesReceived)
+	return p.bytesReceived.Load()
 }
 
 // TimeConnected returns the time at which the peer connected.
@@ -1128,7 +1128,7 @@ func (p *Peer) handlePongMsg(msg *wire.MsgPong) {
 func (p *Peer) readMessage(encoding wire.MessageEncoding) (wire.Message, []byte, error) {
 	n, msg, buf, err := wire.ReadMessageWithEncodingN(p.conn,
 		p.ProtocolVersion(), p.cfg.ChainParams.Net, encoding)
-	atomic.AddUint64(&p.bytesReceived, uint64(n))
+	p.bytesReceived.Add(uint64(n))
 	if p.cfg.Listeners.OnRead != nil {
 		p.cfg.Listeners.OnRead(p, n, msg, err)
 	}
@@ -1160,7 +1160,7 @@ func (p *Peer) readMessage(encoding wire.MessageEncoding) (wire.Message, []byte,
 // writeMessage sends a bitcoin message to the peer with logging.
 func (p *Peer) writeMessage(msg wire.Message, enc wire.MessageEncoding) error {
 	// Don't do anything if we're disconnecting.
-	if atomic.LoadInt32(&p.disconnect) != 0 {
+	if p.disconnect.Load() != 0 {
 		return nil
 	}
 
@@ -1191,7 +1191,7 @@ func (p *Peer) writeMessage(msg wire.Message, enc wire.MessageEncoding) error {
 	// Write the message to the peer.
 	n, err := wire.WriteMessageWithEncodingN(p.conn, msg,
 		p.ProtocolVersion(), p.cfg.ChainParams.Net, enc)
-	atomic.AddUint64(&p.bytesSent, uint64(n))
+	p.bytesSent.Add(uint64(n))
 	if p.cfg.Listeners.OnWrite != nil {
 		p.cfg.Listeners.OnWrite(p, n, msg, err)
 	}
@@ -1233,7 +1233,7 @@ func (p *Peer) isAllowedReadError(err error) bool {
 func (p *Peer) shouldHandleReadError(err error) bool {
 	// No logging or reject message when the peer is being forcibly
 	// disconnected.
-	if atomic.LoadInt32(&p.disconnect) != 0 {
+	if p.disconnect.Load() != 0 {
 		return false
 	}
 
@@ -1458,7 +1458,7 @@ func (p *Peer) inHandler() {
 	})
 
 out:
-	for atomic.LoadInt32(&p.disconnect) == 0 {
+	for p.disconnect.Load() == 0 {
 		// Read a message and stop the idle timer as soon as the read
 		// is done.  The timer is reset below for the next iteration if
 		// needed.
@@ -1508,7 +1508,7 @@ out:
 			}
 			break out
 		}
-		atomic.StoreInt64(&p.lastRecv, time.Now().Unix())
+		p.lastRecv.Store(time.Now().Unix())
 		p.stallControl <- stallControlMsg{sccReceiveMessage, rmsg}
 
 		// Handle each supported message type.
@@ -1822,7 +1822,7 @@ out:
 			// Don't send anything if we're disconnecting or there
 			// is no queued inventory.
 			// version is known if send queue has any entries.
-			if atomic.LoadInt32(&p.disconnect) != 0 ||
+			if p.disconnect.Load() != 0 ||
 				invSendQueue.Len() == 0 {
 				continue
 			}
@@ -1893,7 +1893,7 @@ cleanup:
 // should be logged.
 func (p *Peer) shouldLogWriteError(err error) bool {
 	// No logging when the peer is being forcibly disconnected.
-	if atomic.LoadInt32(&p.disconnect) != 0 {
+	if p.disconnect.Load() != 0 {
 		return false
 	}
 
@@ -1948,7 +1948,7 @@ out:
 			// message that it has been sent (if requested), and
 			// signal the send queue to the deliver the next queued
 			// message.
-			atomic.StoreInt64(&p.lastSend, time.Now().Unix())
+			p.lastSend.Store(time.Now().Unix())
 			if msg.doneChan != nil {
 				msg.doneChan <- struct{}{}
 			}
@@ -2059,20 +2059,20 @@ func (p *Peer) QueueInventory(invVect *wire.InvVect) {
 //
 // This function is safe for concurrent access.
 func (p *Peer) Connected() bool {
-	return atomic.LoadInt32(&p.connected) != 0 &&
-		atomic.LoadInt32(&p.disconnect) == 0
+	return p.connected.Load() != 0 &&
+		p.disconnect.Load() == 0
 }
 
 // Disconnect disconnects the peer by closing the connection.  Calling this
 // function when the peer is already disconnected or in the process of
 // disconnecting will have no effect.
 func (p *Peer) Disconnect() {
-	if atomic.AddInt32(&p.disconnect, 1) != 1 {
+	if p.disconnect.Add(1) != 1 {
 		return
 	}
 
 	log.Debugf("Disconnecting %s", p)
-	if atomic.LoadInt32(&p.connected) != 0 {
+	if p.connected.Load() != 0 {
 		p.conn.Close()
 	}
 	close(p.quit)
@@ -2126,7 +2126,7 @@ func (p *Peer) readRemoteVersionMsg() error {
 	// Set the peer's ID, user agent, and potentially the flag which
 	// specifies the witness support is enabled.
 	p.flagsMtx.Lock()
-	p.id = atomic.AddInt32(&nodeCount, 1)
+	p.id = nodeCount.Add(1)
 	p.userAgent = msg.UserAgent
 
 	p.flagsMtx.Unlock()
@@ -2371,7 +2371,7 @@ func (p *Peer) start() error {
 // function when the peer is already connected will have no effect.
 func (p *Peer) AssociateConnection(conn net.Conn) {
 	// Already connected?
-	if !atomic.CompareAndSwapInt32(&p.connected, 0, 1) {
+	if !p.connected.CompareAndSwap(0, 1) {
 		return
 	}
 
@@ -2489,4 +2489,3 @@ func NewOutboundPeer(cfg *Config, addr string) (*Peer, error) {
 
 	return p, nil
 }
-

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -117,7 +117,7 @@ type jsonRequest struct {
 // the returned future will block until the result is available if it's not
 // already.
 type Client struct {
-	id uint64 // atomic, so must stay 64-bit aligned
+	id atomic.Uint64 // atomic, so must stay 64-bit aligned
 
 	// config holds the connection configuration assoiated with this client.
 	config *ConnConfig
@@ -170,7 +170,7 @@ type Client struct {
 // this function should be used to ensure the ID is unique amongst all requests
 // being made.
 func (c *Client) NextID() uint64 {
-	return atomic.AddUint64(&c.id, 1)
+	return c.id.Add(1)
 }
 
 // addRequest associates the passed jsonRequest with its id.  This allows the


### PR DESCRIPTION
Modernize sync/atomic usage with typed atomic APIs

Replace legacy sync/atomic function-based API (AddInt32, LoadInt32, etc.) 
with Go 1.19+ typed atomic types (atomic.Int32, atomic.Int64, etc.).

This change:
- Improves code readability by removing explicit address-of operators
- Enhances type safety at compile-time
- Provides better API ergonomics with method-based access
- Aligns with modern Go best practices (More info https://github.com/golang/go/issues/50860)

The transformation is source-compatible and requires Go 1.19 or later.

