### PR TITLE
feat: trigger Start9 package build after each release

### DIFF
--- a/.github/workflows/trigger-start9-build.yml
+++ b/.github/workflows/trigger-start9-build.yml
@@ -1,0 +1,30 @@
+name: Trigger Start9 Package Build
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to bitcoin-cash-daemon-startos
+        run: |
+          if [ -z "${{ secrets.START9_BUILD_TOKEN }}" ]; then
+            echo "START9_BUILD_TOKEN not configured — skipping Start9 package trigger"
+            exit 0
+          fi
+          HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.START9_BUILD_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/BitcoinCash1/bitcoin-cash-daemon-startos/dispatches" \
+            -d "{\"event_type\":\"upstream-release\",\"client_payload\":{\"tag\":\"${{ github.event.release.tag_name }}\"}}")
+          if [ "$HTTP_STATUS" = "204" ]; then
+            echo "Start9 package build triggered for tag ${{ github.event.release.tag_name }}"
+          else
+            echo "Warning: GitHub dispatch returned HTTP $HTTP_STATUS — check START9_BUILD_TOKEN"
+            exit 1
+          fi
+        shell: bash


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/trigger-start9-build.yml`
- On every published release, sends a `repository_dispatch` event to [`BitcoinCash1/bitcoin-cash-daemon-startos`](https://github.com/BitcoinCash1/bitcoin-cash-daemon-startos)
- GitHub Actions on that repo auto-bumps the version files, rebuilds the BCHD binary from the new tag, and publishes a `.s9pk` release for [Start9 OS](https://start9.com)

## Setup required (one time)

In this repo, add a secret:
- **Key**: `START9_BUILD_TOKEN`
- **Value**: a GitHub PAT with `repo` scope on `BitcoinCash1/bitcoin-cash-daemon-startos`

If the secret is absent the job exits cleanly — non-blocking.

## What changed

- Added `.github/workflows/trigger-start9-build.yml` — fires on `release: published`, POSTs dispatch event, validates HTTP 204 response