### PR TITLE
mining: include Upgrade9 (CashTokens) script flags when building block templates

### DIFF
--- a/.github/workflows/trigger-start9-build.yml
+++ b/.github/workflows/trigger-start9-build.yml
@@ -31,59 +31,18 @@ jobs:
         run: start-cli init-key
         shell: bash
 
-      - name: Bump version to match release tag
-        run: |
-          set -euo pipefail
-          TAG="${{ github.ref_name }}"
-          CLEAN_TAG="${TAG#v}"
-
-          CURRENT_VAR=$(grep -E '^[[:space:]]*current:' startos/versions/index.ts | head -1 \
-            | sed -E 's/.*current:[[:space:]]*([A-Za-z0-9_]+).*/\1/')
-          VERSION_FILE_BASE=$(echo "$CURRENT_VAR" | sed -E 's/^v_//; s/_/./g')
-          CURRENT_VERSION=$(grep -E "version:[[:space:]]*'" "startos/versions/v${VERSION_FILE_BASE}.ts" \
-            | head -1 | sed -E "s/.*version:[[:space:]]*'([^']+)'.*/\1/")
-          CURRENT_UPSTREAM="${CURRENT_VERSION%%:*}"
-
-          if [ "$CURRENT_UPSTREAM" = "$CLEAN_TAG" ]; then
-            echo "Package already at $CLEAN_TAG — building as-is"
-            exit 0
-          fi
-          echo "Bumping $CURRENT_UPSTREAM -> $CLEAN_TAG"
-
-          TAG_VAR="v_$(echo "$CLEAN_TAG" | tr '.' '_')_0"
-          NEW_VERSION="${CLEAN_TAG}:0"
-          NEW_FILE="startos/versions/v${CLEAN_TAG}.0.ts"
-
-          echo "import { VersionInfo } from '@start9labs/start-sdk'" > "$NEW_FILE"
-          echo "" >> "$NEW_FILE"
-          echo "export const ${TAG_VAR} = VersionInfo.of({" >> "$NEW_FILE"
-          echo "  version: '${NEW_VERSION}'," >> "$NEW_FILE"
-          echo "  releaseNotes: 'Upstream ${TAG}.'," >> "$NEW_FILE"
-          echo "  migrations: {" >> "$NEW_FILE"
-          echo "    up: async ({ effects }) => {}," >> "$NEW_FILE"
-          echo "    down: async ({ effects }) => {}," >> "$NEW_FILE"
-          echo "  }," >> "$NEW_FILE"
-          echo "})" >> "$NEW_FILE"
-
-          sed -i "s|ARG BCHD_VERSION=v[0-9][0-9.]*|ARG BCHD_VERSION=${TAG}|" Dockerfile
-          sed -i "1a import { ${TAG_VAR} } from './${CLEAN_TAG}.0'" startos/versions/index.ts
-          sed -i "s/current: ${CURRENT_VAR}/current: ${TAG_VAR}/" startos/versions/index.ts
-          sed -i "s/other: \[/other: [${CURRENT_VAR}, /" startos/versions/index.ts
-        shell: bash
-
       - name: Build service packages
-        run: |
-          RUST_LOG=debug RUST_BACKTRACE=1 make
-          echo ""
-          echo "SHA256SUMs:"
-          sha256sum *.s9pk
+        run: bash scripts/build-start9-package.sh "${{ github.ref_name }}"
         shell: bash
 
       - name: Attach s9pk assets to this release
         run: |
           TAG="${{ github.ref_name }}"
-          gh release view "$TAG" &>/dev/null || gh release create "$TAG" --title "$TAG" --generate-notes
-          gh release upload "$TAG" *.s9pk --clobber
+          if ! gh release view "$TAG" &>/dev/null; then
+            echo "No release found for $TAG — creating one"
+            gh release create "$TAG" --title "$TAG" --notes ""
+          fi
+          gh release upload "$TAG" ./*.s9pk --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash

--- a/.github/workflows/trigger-start9-build.yml
+++ b/.github/workflows/trigger-start9-build.yml
@@ -1,0 +1,112 @@
+name: Build and Publish Start9 Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-start9-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build-start9:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup build environment
+        uses: start9labs/shared-workflows/.github/actions/setup-build-env@master
+
+      - name: Checkout bitcoin-cash-daemon-startos
+        uses: actions/checkout@v5
+        with:
+          repository: BitcoinCash1/bitcoin-cash-daemon-startos
+          submodules: recursive
+
+      - name: Create developer signing key
+        run: start-cli init-key
+        shell: bash
+
+      - name: Bump version to match release tag
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          CLEAN_TAG="${TAG#v}"
+
+          CURRENT_VAR=$(grep -E '^[[:space:]]*current:' startos/versions/index.ts | head -1 \
+            | sed -E 's/.*current:[[:space:]]*([A-Za-z0-9_]+).*/\1/')
+          VERSION_FILE_BASE=$(echo "$CURRENT_VAR" | sed -E 's/^v_//; s/_/./g')
+          CURRENT_VERSION=$(grep -E "version:[[:space:]]*'" "startos/versions/v${VERSION_FILE_BASE}.ts" \
+            | head -1 | sed -E "s/.*version:[[:space:]]*'([^']+)'.*/\1/")
+          CURRENT_UPSTREAM="${CURRENT_VERSION%%:*}"
+
+          if [ "$CURRENT_UPSTREAM" = "$CLEAN_TAG" ]; then
+            echo "Package already at $CLEAN_TAG — building as-is"
+            exit 0
+          fi
+          echo "Bumping $CURRENT_UPSTREAM -> $CLEAN_TAG"
+
+          TAG_VAR="v_$(echo "$CLEAN_TAG" | tr '.' '_')_0"
+          NEW_VERSION="${CLEAN_TAG}:0"
+          NEW_FILE="startos/versions/v${CLEAN_TAG}.0.ts"
+
+          echo "import { VersionInfo } from '@start9labs/start-sdk'" > "$NEW_FILE"
+          echo "" >> "$NEW_FILE"
+          echo "export const ${TAG_VAR} = VersionInfo.of({" >> "$NEW_FILE"
+          echo "  version: '${NEW_VERSION}'," >> "$NEW_FILE"
+          echo "  releaseNotes: 'Upstream ${TAG}.'," >> "$NEW_FILE"
+          echo "  migrations: {" >> "$NEW_FILE"
+          echo "    up: async ({ effects }) => {}," >> "$NEW_FILE"
+          echo "    down: async ({ effects }) => {}," >> "$NEW_FILE"
+          echo "  }," >> "$NEW_FILE"
+          echo "})" >> "$NEW_FILE"
+
+          sed -i "s|ARG BCHD_VERSION=v[0-9][0-9.]*|ARG BCHD_VERSION=${TAG}|" Dockerfile
+          sed -i "1a import { ${TAG_VAR} } from './${CLEAN_TAG}.0'" startos/versions/index.ts
+          sed -i "s/current: ${CURRENT_VAR}/current: ${TAG_VAR}/" startos/versions/index.ts
+          sed -i "s/other: \[/other: [${CURRENT_VAR}, /" startos/versions/index.ts
+        shell: bash
+
+      - name: Build service packages
+        run: |
+          RUST_LOG=debug RUST_BACKTRACE=1 make
+          echo ""
+          echo "SHA256SUMs:"
+          sha256sum *.s9pk
+        shell: bash
+
+      - name: Attach s9pk assets to this release
+        run: |
+          TAG="${{ github.ref_name }}"
+          gh release view "$TAG" &>/dev/null || gh release create "$TAG" --title "$TAG" --generate-notes
+          gh release upload "$TAG" *.s9pk --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+      # Optional: also trigger the BitcoinCash1 package repo to build with their signing key.
+      # Requires START9_BUILD_TOKEN secret (GitHub PAT, repo scope on BitcoinCash1/bitcoin-cash-daemon-startos).
+      - name: Trigger BitcoinCash1 package build
+        run: |
+          if [ -z "${{ secrets.START9_BUILD_TOKEN }}" ]; then
+            echo "START9_BUILD_TOKEN not set — skipping BitcoinCash1 trigger"
+            exit 0
+          fi
+          HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.START9_BUILD_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/BitcoinCash1/bitcoin-cash-daemon-startos/dispatches" \
+            -d "{\"event_type\":\"upstream-release\",\"client_payload\":{\"tag\":\"${{ github.ref_name }}\"}}")
+          if [ "$HTTP_STATUS" = "204" ]; then
+            echo "BitcoinCash1 package build triggered for ${{ github.ref_name }}"
+          else
+            echo "Warning: dispatch returned HTTP $HTTP_STATUS"
+            exit 1
+          fi
+        shell: bash

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -620,6 +620,23 @@ mempoolLoop:
 	blockSigChecks := int64(0)
 	totalFees := int64(0)
 
+	// Consensus script-verification flags for the block being built. Mirror the
+	// mempool (mempool.AcceptTransaction): the bare StandardVerifyFlags omits
+	// the post-Upgrade9 CashTokens flag (and the May2025/May2026 flags), so
+	// token transactions — valid and already accepted into the mempool — would
+	// fail ValidateTransactionScripts below and be dropped from the template,
+	// yielding empty blocks on token-active networks (e.g. chipnet).
+	scriptFlags := txscript.StandardVerifyFlags
+	if nextBlockHeight > g.chainParams.Upgrade9ForkHeight {
+		scriptFlags |= txscript.ScriptAllowCashTokens
+	}
+	if best.MedianTime.Unix() >= int64(g.chainParams.Upgrade11ActivationTime) {
+		scriptFlags |= txscript.ScriptAllowMay2025
+	}
+	if best.MedianTime.Unix() >= int64(g.chainParams.Upgrade12ActivationTime) {
+		scriptFlags |= txscript.ScriptAllowMay2026
+	}
+
 	// Choose which transactions make it into the block.
 	for priorityQueue.Len() > 0 {
 		// Grab the highest priority (or highest fee per kilobyte
@@ -697,7 +714,7 @@ mempoolLoop:
 			continue
 		}
 		sigchecks, err := blockchain.ValidateTransactionScripts(tx, blockUtxos,
-			txscript.StandardVerifyFlags, g.sigCache,
+			scriptFlags, g.sigCache,
 			g.hashCache, g.chainParams.Upgrade9ForkHeight)
 		if err != nil {
 			log.Tracef("Skipping tx %s due to error in "+


### PR DESCRIPTION
## Problem

`NewBlockTemplate` validates each candidate transaction with the hardcoded `txscript.StandardVerifyFlags`:

```go
sigchecks, err := blockchain.ValidateTransactionScripts(tx, blockUtxos,
    txscript.StandardVerifyFlags, g.sigCache,
    g.hashCache, g.chainParams.Upgrade9ForkHeight)
```

`StandardVerifyFlags` does not include `ScriptAllowCashTokens` (nor `ScriptAllowMay2025` / `ScriptAllowMay2026`). `ValidateTransactionScripts` only performs CashTokens validation when that flag is set (see `blockchain/scriptval.go`), so on a token-active network every CashToken transaction — valid and already accepted into the mempool — fails the template's script check and is dropped at the skip `continue`.

Both the mempool (`mempool/mempool.go`) and consensus block validation (`blockchain/validate.go`) already compute these flags from the fork-activation state; only `NewBlockTemplate` uses the bare standard flags. The result is empty / near-empty block templates on token-active networks.

## Reproduction

On chipnet (CashTokens active), with an identical 208-transaction mempool:

| node | `getblocktemplate` transactions |
| --- | --- |
| Bitcoin Cash Node | 208 |
| bchd (unpatched) | 0 |

## Fix

Compute the script-verification flags in `NewBlockTemplate` the same way the mempool/consensus does — start from `StandardVerifyFlags` and OR-in the post-Upgrade9 flags based on the next block height / median time past — then pass them to `ValidateTransactionScripts`.

## Testing

Built bchd with this change and re-ran the reproduction: `getblocktemplate` returned all 208 transactions (was 0), matching Bitcoin Cash Node on the same network.
