### PR TITLE
fix: reject raw transactions with trailing bytes

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -834,11 +834,22 @@ func handleDecodeRawTransaction(s *rpcServer, cmd interface{}, closeNotifier <-c
 		return nil, rpcDecodeHexError(hexStr)
 	}
 	var mtx wire.MsgTx
-	err = mtx.Deserialize(bytes.NewReader(serializedTx))
+	txReader := bytes.NewReader(serializedTx)
+	err = mtx.Deserialize(txReader)
 	if err != nil {
 		return nil, &btcjson.RPCError{
 			Code:    btcjson.ErrRPCDeserialization,
 			Message: "TX decode failed: " + err.Error(),
+		}
+	}
+
+	// The transaction must consume the entire input.  Anything left over
+	// means the caller supplied a malformed transaction, so reject it rather
+	// than silently ignoring the surplus.
+	if txReader.Len() != 0 {
+		return nil, &btcjson.RPCError{
+			Code:    btcjson.ErrRPCDeserialization,
+			Message: "TX decode failed: unexpected trailing bytes",
 		}
 	}
 
@@ -3685,11 +3696,22 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeNotifier <-cha
 		return nil, rpcDecodeHexError(hexStr)
 	}
 	var msgTx wire.MsgTx
-	err = msgTx.Deserialize(bytes.NewReader(serializedTx))
+	txReader := bytes.NewReader(serializedTx)
+	err = msgTx.Deserialize(txReader)
 	if err != nil {
 		return nil, &btcjson.RPCError{
 			Code:    btcjson.ErrRPCDeserialization,
 			Message: "TX decode failed: " + err.Error(),
+		}
+	}
+
+	// The transaction must consume the entire input.  Anything left over
+	// means the caller supplied a malformed transaction, so reject it rather
+	// than relaying it to the rest of the network.
+	if txReader.Len() != 0 {
+		return nil, &btcjson.RPCError{
+			Code:    btcjson.ErrRPCDeserialization,
+			Message: "TX decode failed: unexpected trailing bytes",
 		}
 	}
 

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 The bchd developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/gcash/bchd/btcjson"
+	"github.com/gcash/bchd/chaincfg/chainhash"
+	"github.com/gcash/bchd/wire"
+)
+
+// txHexWithTrailingBytes returns the hex encoding of a minimal but otherwise
+// valid transaction with an extra byte appended to it.  The result decodes to a
+// complete transaction without consuming all of the provided input, which is
+// exactly the case both raw transaction RPCs must reject.
+func txHexWithTrailingBytes(t *testing.T) string {
+	t.Helper()
+
+	tx := wire.NewMsgTx(1)
+	tx.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&chainhash.Hash{}, 0), nil))
+	tx.AddTxOut(wire.NewTxOut(0, nil, wire.TokenData{}))
+
+	var buf bytes.Buffer
+	if err := tx.Serialize(&buf); err != nil {
+		t.Fatalf("unable to serialize test transaction: %v", err)
+	}
+
+	return hex.EncodeToString(append(buf.Bytes(), 0x00))
+}
+
+// assertDeserializationError ensures the provided error is an RPC
+// deserialization error.
+func assertDeserializationError(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected trailing bytes to be rejected, got no error")
+	}
+
+	rpcErr, ok := err.(*btcjson.RPCError)
+	if !ok {
+		t.Fatalf("expected *btcjson.RPCError, got %T: %v", err, err)
+	}
+
+	if rpcErr.Code != btcjson.ErrRPCDeserialization {
+		t.Fatalf("expected error code %v, got %v (%v)",
+			btcjson.ErrRPCDeserialization, rpcErr.Code, rpcErr.Message)
+	}
+}
+
+// TestHandleDecodeRawTransactionTrailingBytes ensures decoderawtransaction
+// rejects a transaction that is followed by trailing bytes rather than
+// silently ignoring them and reporting success.
+func TestHandleDecodeRawTransactionTrailingBytes(t *testing.T) {
+	cmd := &btcjson.DecodeRawTransactionCmd{
+		HexTx: txHexWithTrailingBytes(t),
+	}
+
+	// The handler decodes its input before it touches the server, so a nil
+	// server is sufficient to exercise the rejection path.
+	_, err := handleDecodeRawTransaction(nil, cmd, nil)
+	assertDeserializationError(t, err)
+}
+
+// TestHandleSendRawTransactionTrailingBytes ensures sendrawtransaction rejects
+// a transaction that is followed by trailing bytes rather than accepting and
+// relaying it.
+func TestHandleSendRawTransactionTrailingBytes(t *testing.T) {
+	allowHighFees := false
+	cmd := &btcjson.SendRawTransactionCmd{
+		HexTx:         txHexWithTrailingBytes(t),
+		AllowHighFees: &allowHighFees,
+	}
+
+	// As above, the decode happens before the mempool is reached, so a nil
+	// server is sufficient.  Without the trailing byte check this panics on
+	// the nil server instead of returning, which is the symptom this test
+	// guards against.
+	_, err := handleSendRawTransaction(nil, cmd, nil)
+	assertDeserializationError(t, err)
+}


### PR DESCRIPTION
## Change Description

`decoderawtransaction` and `sendrawtransaction` deserialize the caller supplied hex without checking that the transaction consumed all of it. Surplus bytes past the end of an otherwise well formed transaction are silently discarded and the call reports success.

For `sendrawtransaction` this is more than cosmetic: a malformed payload is accepted and the decoded transaction is then relayed on to the rest of the network.

Both handlers already return `TX decode failed` when deserialization itself fails, so accepting input that does not decode cleanly looks like an oversight rather than intentional leniency.

btcd, which this project forked from, tightened these same two handlers in btcsuite/btcd#2558 (merged), which consolidated my btcsuite/btcd#2550 (`decoderawtransaction`) and btcsuite/btcd#2556 (`sendrawtransaction`). This ports the equivalent check to bchd.

## Fix

Read through a `*bytes.Reader` and reject any input that is not fully consumed, with `ErrRPCDeserialization`.

## Steps to Test

```
go test -run TrailingBytes .
```

Both regression tests fail with the fix reverted. Each handler decodes its input before it touches the server, so a nil server is enough to exercise the rejection path — without the check, execution reaches the nil server and panics instead of returning, which is the symptom the tests guard against. I verified this locally both ways: removing the two checks makes both tests fail, restoring them makes them pass. The full `go test .` suite is green, as are `go build ./...` and `go vet .`.

Note on gofmt: `rpcserver.go` is flagged by `gofmt -l` on my checkout, but this is a pre-existing CRLF artifact of cloning on Windows — it is flagged identically on an unmodified checkout, and the file is clean once converted to LF. Git stores LF on commit.