### PR TITLE
version: preserve semantic version separators

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
 
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -25,6 +25,10 @@ func TestString(t *testing.T) {
 			build:    "012-abc",
 			expected: base + "+012-abc",
 		}, {
+			name:     "with-dotted-build",
+			build:    "exp.sha.5114f85",
+			expected: base + "+exp.sha.5114f85",
+		}, {
 			name:     "with-out-of-spec-build",
 			build:    "012_abc",
 			expected: base,


### PR DESCRIPTION
SemVer separates pre-release identifiers and build metadata with periods, but `semanticAlphabet` omits the period.

`String()` uses `normalizeVerString` as a validator rather than a sanitizer — it only appends the metadata when the string round-trips unchanged:

```go
if appBuild != "" {
    build := normalizeVerString(appBuild)
    if build == appBuild {
        version = fmt.Sprintf("%s+%s", version, build)
    }
}
```

So a dot-separated build stamp is not mangled, it is **dropped from the version entirely**, as if it had never been set. Adding a case to `TestString` shows it on master:

```
--- FAIL: TestString
    version_test.go:42: with-dotted-build: expected 0.22.2+exp.sha.5114f85, got 0.22.2
```

This is reachable rather than latent. `appBuild` is documented as settable at build time via `-ldflags`, and SemVer build metadata is dot-separated — `exp.sha.5114f85` is an example from the spec itself. The same applies to `AppPreRelease`: a value like `beta.rc1` would be dropped rather than reported.

The existing `with-out-of-spec-build` case (`012_abc`, underscore) still passes, so genuinely invalid metadata is still rejected.

btcd, which this code came from, fixed its copy in [65db493](https://github.com/btcsuite/btcd/commit/65db49397a59fb10fd5a954df19bda33ce4e5e5d) ("version: preserve semantic version separators", btcsuite/btcd#2578).

`go build ./...`, `go test ./version/`, `gofmt` and `go vet` are clean.

One thing I noticed but left alone to keep the diff to the fix: the comment above `appBuild` says `-X main.appBuild`, but this copy lives in package `version`, so the flag is really `-X github.com/gcash/bchd/version.appBuild`. It was accurate before the code moved out of `main`.

---

*Disclosure: written with AI assistance; the analysis, fix and test were verified locally.*
