### PR TITLE
chaincfg: fix panic wording in test comment

### DIFF
--- a/chaincfg/params_test.go
+++ b/chaincfg/params_test.go
@@ -23,7 +23,7 @@ func TestMustRegisterPanic(t *testing.T) {
 	t.Parallel()
 
 	// Setup a defer to catch the expected panic to ensure it actually
-	// paniced.
+	// panicked.
 	defer func() {
 		if err := recover(); err == nil {
 			t.Error("mustRegister did not panic as expected")


### PR DESCRIPTION
Corrects the past tense of “panic” in `TestMustRegisterPanic`'s explanatory comment.

This is a comment-only change and does not affect test behavior.

Tested with `go test ./chaincfg`.