### PR TITLE
bchec: propagate MuSig randomness errors

### DIFF
--- a/bchec/musig.go
+++ b/bchec/musig.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"sort"
 )
@@ -22,7 +23,9 @@ func AggregatePublicKeys(keys ...*PublicKey) (*PublicKey, error) {
 // hash using the provided private keys.
 func SignMuSig(hash []byte, keys ...*PrivateKey) (*Signature, error) {
 	sessionID := make([]byte, 32)
-	rand.Read(sessionID)
+	if _, err := io.ReadFull(rand.Reader, sessionID); err != nil {
+		return nil, fmt.Errorf("generate MuSig session ID: %w", err)
+	}
 
 	// Sort the private keys by their corresponding public keys
 	sort.Slice(keys, func(i, j int) bool {

--- a/bchec/musig_test.go
+++ b/bchec/musig_test.go
@@ -3,10 +3,19 @@ package bchec
 import (
 	crand "crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"math/big"
 	"math/rand"
 	"testing"
 )
+
+var errTestRandomness = errors.New("randomness unavailable")
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errTestRandomness
+}
 
 func TestMuSession(t *testing.T) {
 	m := sha256.Sum256([]byte("hello world"))
@@ -104,6 +113,24 @@ func TestSignMuSig(t *testing.T) {
 		if !valid {
 			t.Fatal("invalid signature")
 		}
+	}
+}
+
+func TestSignMuSigRandomnessError(t *testing.T) {
+	priv, err := NewPrivateKey(S256())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalReader := crand.Reader
+	crand.Reader = errorReader{}
+	t.Cleanup(func() {
+		crand.Reader = originalReader
+	})
+
+	_, err = SignMuSig(make([]byte, 32), priv)
+	if !errors.Is(err, errTestRandomness) {
+		t.Fatalf("expected randomness error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
SignMuSig previously ignored failures while filling the session ID used for nonce derivation.

Use io.ReadFull with crypto/rand.Reader so the ID is fully populated or the caller receives a wrapped error. The regression test replaces the reader with a failing source and verifies error propagation.