### PR TITLE
bchec: use slices.SortFunc for MuSig key ordering

### DIFF
--- a/bchec/musig.go
+++ b/bchec/musig.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"sort"
+	"slices"
 )
 
 // AggregatePublicKeys aggregates the given public keys using
@@ -25,8 +25,8 @@ func SignMuSig(hash []byte, keys ...*PrivateKey) (*Signature, error) {
 	rand.Read(sessionID)
 
 	// Sort the private keys by their corresponding public keys
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i].PubKey().X.Cmp(keys[j].PubKey().X) < 0
+	slices.SortFunc(keys, func(a, b *PrivateKey) int {
+		return a.PubKey().X.Cmp(b.PubKey().X)
 	})
 
 	pubkeys := make([]*PublicKey, 0, len(keys))
@@ -265,7 +265,7 @@ func calculateAggregateSignature(aggregateNonce *PublicKey, svals ...*big.Int) *
 }
 
 func sortPubkeys(keys []*PublicKey) {
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i].X.Cmp(keys[j].X) < 0
+	slices.SortFunc(keys, func(a, b *PublicKey) int {
+		return a.X.Cmp(b.X)
 	})
 }


### PR DESCRIPTION
Replace both index-based MuSig key sorting callbacks with typed `slices.SortFunc` comparators.

The comparators now reuse `big.Int.Cmp` directly. This keeps the existing key ordering while removing slice-index capture and comparator boilerplate.

